### PR TITLE
gitignore: Visual Studio 2015 database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /desmume/src/frontend/windows/*.aps
 *.user
 *.suo
+*.VC.db
 *.o
 .deps
 *.dirstamp


### PR DESCRIPTION
Visual Studio 2015 produces an extra .VC.db file when building any
solution