### PR TITLE
Don't run strcpy if source and destination are equal.

### DIFF
--- a/desmume/src/emufile.h
+++ b/desmume/src/emufile.h
@@ -285,7 +285,9 @@ private:
 		if(!fp)
 			failbit = true;
 		this->fname = fname;
-		strcpy(this->mode,mode);
+		if (this->mode != mode) {
+			strcpy(this->mode,mode);
+		}
 	}
 
 public:


### PR DESCRIPTION
This fixes a bug that shows up by running desmume with address sanitizer, which is a compiler memory check feature. It can be reproduced by compiling desmume with CFLAGS/CXXFLAGS set to "-fsanitize=address -g", then run the gtk interface and trying to open an image.

The bug is that there's a strcpy call where sometimes the source and destination pointer are identical (so the strcpy doesn't actually do anything). This is not valid c code, as the parameters of strcpy are not allowed to overlap. This can be fixed by simply checking whether the pointers are identical and not do anything in that case.