### PR TITLE
Add rtc-day/hour options to override NDS clock

### DIFF
--- a/desmume/src/commandline.h
+++ b/desmume/src/commandline.h
@@ -107,6 +107,8 @@ private:
 	char *_slot1_fat_dir;
 	char* _console_type;
 	char* _advanscene_import;
+	int _rtc_day;
+	int _rtc_hour;
 };
 
 #endif

--- a/desmume/src/rtc.cpp
+++ b/desmume/src/rtc.cpp
@@ -29,6 +29,7 @@
 #endif
 #include "movie.h"
 
+int rtcHourOverride = 0;
 
 typedef struct
 {
@@ -95,9 +96,8 @@ bool moviemode=false;
 
 DateTime rtcGetTime(void)
 {
-	DateTime tm;
 	if(movieMode == MOVIEMODE_INACTIVE) {
-		return DateTime::get_Now();
+		return DateTime::get_Now().AddHours(rtcHourOverride);
 	}
 	else {
 		//now, you might think it is silly to go through all these conniptions

--- a/desmume/src/rtc.h
+++ b/desmume/src/rtc.h
@@ -24,6 +24,8 @@
 #include "types.h"
 #include "utils/datetime.h"
 
+extern int rtcHourOverride;
+
 DateTime rtcGetTime(void);
 void rtcGetTimeAsString(char *buffer);
 


### PR DESCRIPTION
--rtc-day and --rtc-hour may be used to override the emulated time.
rtc-day is a day of week (0-6) rtc-hour is the hour (0-23). Time
difference is calculated at emulator start and the emulated RTC then
reports time from the future. This difference is then maintained so that
an hour after the emulator is started means an hour passes according
to the RTC.