### PR TITLE
fix: add missing comma in ZIPROMReader definition

### DIFF
--- a/desmume/src/ROMReader.cpp
+++ b/desmume/src/ROMReader.cpp
@@ -221,7 +221,7 @@ ROMReader_struct ZIPROMReader =
 	ZIPROMReaderDeInit,
 	ZIPROMReaderSize,
 	ZIPROMReaderSeek,
-	ZIPROMReaderRead
+	ZIPROMReaderRead,
 	ZIPROMReaderWrite
 };
 


### PR DESCRIPTION
This was omitted in c365617ff737bdb3c06c307159078ca4e5f7e175; the other
ROMReader_structs it updated were correct.