### PR TITLE
Let the game not because the ROM title characters of the problem can not be opened.

### DIFF
--- a/desmume/src/NDSSystem.cpp
+++ b/desmume/src/NDSSystem.cpp
@@ -336,9 +336,12 @@ bool GameInfo::ValidateHeader()
 			char c = (char)header.gameTile[i];
 			if (c < 0 || (c > 0 && c < 32) || c == 127)
 			{
+				printf("\n[WARNING] ");
 				printf("ROM Validation: Invalid character detected in ROM Title.\n");
 				printf("                charIndex = %d, charValue = %d\n", (int)i, c);
-				return isRomValid;
+				//make sure the ROMname is ASCII clean, and use the ? to replace special characters.
+				header.gameTile[i] = '?';
+				//return isRomValid;
 			}
 		}
 		


### PR DESCRIPTION
Let the game not because the ROM title characters of the problem can not be opened.
But warning on the console!
Give some of the modified ROM a chance to run, such as MM2R NEX.
(after: a738364416119194ef2ef8b6180fdd8c50da8079)
