### PR TITLE
Update remaining stub versions of mic_savestate/loadstate.

### DIFF
--- a/desmume/src/frontend/posix/shared/mic_alsa.cpp
+++ b/desmume/src/frontend/posix/shared/mic_alsa.cpp
@@ -162,13 +162,13 @@ u8 Mic_ReadSample()
 }
 
 /* FIXME: stub! */
-void mic_savestate(EMUFILE* os)
+void mic_savestate(EMUFILE &os)
 {
-    write32le((u32)(-1),os);
+    os.write_32LE(-1);
 }
 
-bool mic_loadstate(EMUFILE* is, int size) 
+bool mic_loadstate(EMUFILE &is, int size) 
 {
-    is->fseek(size, SEEK_CUR);
+    is.fseek(size, SEEK_CUR);
     return TRUE;
 }

--- a/desmume/src/frontend/posix/shared/mic_openal.cpp
+++ b/desmume/src/frontend/posix/shared/mic_openal.cpp
@@ -154,14 +154,14 @@ u8 Mic_ReadSample()
   return ret;
 }
 
-void mic_savestate(EMUFILE* os)
+void mic_savestate(EMUFILE &os)
 {
-	write32le(-1,os);
+	os.write_32LE(-1);
 }
 
-bool mic_loadstate(EMUFILE* is, int size)
+bool mic_loadstate(EMUFILE &is, int size)
 {
-	is->fseek(size, SEEK_CUR);
+	is.fseek(size, SEEK_CUR);
 	return TRUE;
 }
 

--- a/desmume/src/mic.cpp
+++ b/desmume/src/mic.cpp
@@ -197,7 +197,7 @@ void Mic_DoNoise(BOOL noise)
 
 void mic_savestate(EMUFILE &os)
 {
-	write_32LE(-1,os);
+	os.write_32LE(-1);
 }
 
 bool mic_loadstate(EMUFILE &is, int size)


### PR DESCRIPTION
11cf901336d77574e0f2c3482e130e05fa5f03e4 changed most of these but
missed these three.