### PR TITLE
Fix broken option list in POSIX frontend

### DIFF
--- a/desmume/src/frontend/posix/cli/main.cpp
+++ b/desmume/src/frontend/posix/cli/main.cpp
@@ -182,7 +182,6 @@ fill_config( class configured_features *config,
     "SAVETYPE"},
 #ifdef INCLUDE_OPENGL_2D
     { "opengl-2d", 0, 0, G_OPTION_ARG_NONE, &config->opengl_2d, "Enables using OpenGL for screen rendering", NULL},
-     NULL},
 #endif
     { "fwlang", 0, 0, G_OPTION_ARG_INT, &config->firmware_language, "Set the language in the firmware, LANG as follows:\n"
     "\t\t\t\t\t\t  0 = Japanese\n"


### PR DESCRIPTION
f5c9a36930f1fa0889e89080e210063bee623172 tried to remove an entry from
the list of options, but only deleted half of it.