### PR TITLE
Windows Port: Adding Pen and Touch support for touch screen devices

### DIFF
--- a/desmume/src/frontend/windows/main.cpp
+++ b/desmume/src/frontend/windows/main.cpp
@@ -5171,16 +5171,41 @@ DOKEYDOWN:
 		}
 		return 0;
 
+	#ifndef WM_POINTERDOWN
+		#define WM_POINTERDOWN   0x0246
+	#endif
+	#ifndef WM_POINTERUPDATE
+		#define WM_POINTERUPDATE   0x0245
+	#endif
+	#ifndef POINTER_MESSAGE_FLAG_INCONTACT
+		#define POINTER_MESSAGE_FLAG_INCONTACT   0x40000
+	#endif
+	#ifndef POINTER_MESSAGE_FLAG_FIRSTBUTTON
+		#define POINTER_MESSAGE_FLAG_FIRSTBUTTON   0x100000
+	#endif
+	case WM_POINTERDOWN:
+	case WM_POINTERUPDATE:
+
 	case WM_MOUSEMOVE:
 	case WM_LBUTTONDOWN:
 	case WM_LBUTTONDBLCLK:
-		if (wParam & MK_LBUTTON)
+		if (((message==WM_POINTERDOWN || message== WM_POINTERUPDATE)
+			&& ((wParam & (POINTER_MESSAGE_FLAG_INCONTACT | POINTER_MESSAGE_FLAG_FIRSTBUTTON))))
+			|| (message != WM_POINTERDOWN && message != WM_POINTERUPDATE && (wParam & MK_LBUTTON)))
 		{
 			SetCapture(hwnd);
 
 			s32 x = (s32)((s16)LOWORD(lParam));
 			s32 y = (s32)((s16)HIWORD(lParam));
-
+			if (message == WM_POINTERDOWN || message == WM_POINTERUPDATE)
+			{
+				POINT point;
+				point.x = x;
+				point.y = y;
+				ScreenToClient(hwnd, &point);
+				x = point.x;
+				y = point.y;
+			}
 			UnscaleScreenCoords(x,y);
 
 			if(HudEditorMode)
@@ -5232,10 +5257,21 @@ DOKEYDOWN:
 				return 0;
 			}
 		}
+		else if (message == WM_POINTERUPDATE
+			&& !(wParam & POINTER_MESSAGE_FLAG_INCONTACT | POINTER_MESSAGE_FLAG_FIRSTBUTTON))
+		{
+			ReleaseCapture();
+			HudClickRelease(&Hud);
+		}
 		if (!StylusAutoHoldPressed)
 			NDS_releaseTouch();
 		userTouchesScreen = false;
 		return 0;
+
+	#ifndef WM_POINTERUP
+		#define WM_POINTERUP   0x0247
+	#endif
+	case WM_POINTERUP:
 
 	case WM_LBUTTONUP:
 


### PR DESCRIPTION
Noticed that a recent Windows update made my touch screen work unexpectedly with desmume, perhaps a bad driver issue or a change in how Windows interprets touch screen input as mouse events.

Regardless, I added support for some of the [WM_POINTER* family of messages](https://msdn.microsoft.com/en-us/library/hh454903(v=vs.85).aspx) which fixed the issue.