### PR TITLE
Fix movies starting from SRAM

### DIFF
--- a/desmume/src/movie.cpp
+++ b/desmume/src/movie.cpp
@@ -604,8 +604,8 @@ static void openRecordingMovie(const char* fname)
 
 bool MovieData::loadSramFrom(std::vector<u8>* buf)
 {
-	EMUFILE_MEMORY ms(buf);
-	MMU_new.backupDevice.load_movie(ms);
+	EMUFILE_MEMORY *ms = new EMUFILE_MEMORY(buf);
+	MMU_new.backupDevice.load_movie(*ms);
 	return true;
 }
 


### PR DESCRIPTION
Hopefully now TASing can be done with a later version than 0.9.9 without desync issues.

(The EMUFILE_MEMORY object was being destructed upon exiting the loadSramFrom method; now it will not be.)