### PR TITLE
Properly handle SRAM while playing movies.

### DIFF
--- a/desmume/src/mc.cpp
+++ b/desmume/src/mc.cpp
@@ -216,7 +216,6 @@ BackupDevice::BackupDevice()
 	fpMC = NULL;
 	fsize = 0;
 	addr_size = 0;
-	isMovieMode = false;
 
 	//default for most games; will be altered where appropriate
 	//usually 0xFF, but occasionally others. If these exceptions could be related to a particular backup memory type, that would be helpful.
@@ -519,44 +518,36 @@ bool  BackupDevice::write(u8 val)
 #ifdef _DONT_SAVE_BACKUP
 	return true;
 #endif
-	//never use save files if we are in movie mode
-	if (isMovieMode) return true;
 
 	return (fpMC->fwrite(&val, 1) == 1);
 }
 
 void BackupDevice::writeByte(u32 addr, u8 val)
 {
-	if (isMovieMode) return;
 	fpMC->fseek(addr, SEEK_SET);
 	fpMC->write_u8(val);
 }
 void BackupDevice::writeWord(u32 addr, u16 val)
 {
-	if (isMovieMode) return;
 	fpMC->fseek(addr, SEEK_SET);
 	fpMC->write_16LE(val);
 }
 void BackupDevice::writeLong(u32 addr, u32 val)
 {
-	if (isMovieMode) return;
 	fpMC->fseek(addr, SEEK_SET);
 	fpMC->write_32LE(val);
 }
 
 void BackupDevice::writeByte(u8 val)
 {
-	if (isMovieMode) return;
 	fpMC->write_u8(val);
 }
 void BackupDevice::writeWord(u16 val)
 {
-	if (isMovieMode) return;
 	fpMC->write_16LE(val);
 }
 void BackupDevice::writeLong(u32 val)
 {
-	if (isMovieMode) return;
 	fpMC->write_32LE(val);
 }
 
@@ -586,7 +577,6 @@ bool BackupDevice::saveBuffer(u8 *data, u32 size, bool _rewind, bool _truncate)
 
 void BackupDevice::movie_mode()
 {
-	isMovieMode = true;
 	reset();
 }
 
@@ -1694,6 +1684,14 @@ bool BackupDevice::load_movie(EMUFILE &is)
 	//none of the other fields are used right now
 
 	return true;
+}
+
+void BackupDevice::load_movie_blank()
+{
+	delete fpMC;
+	fpMC = new EMUFILE_MEMORY();
+
+	state = DETECTING;
 }
 
 void BackupDevice::forceManualBackupType()

--- a/desmume/src/mc.h
+++ b/desmume/src/mc.h
@@ -148,8 +148,7 @@ public:
 	bool no_gba_unpack(u8 *&buf, u32 &size);
 	
 	bool load_movie(EMUFILE &is);
-
-	bool isMovieMode;
+	void load_movie_blank();
 
 	u32 importDataSize(const char *filename);
 	bool importData(const char *filename, u32 force_size = 0);

--- a/desmume/src/movie.cpp
+++ b/desmume/src/movie.cpp
@@ -604,8 +604,8 @@ static void openRecordingMovie(const char* fname)
 
 bool MovieData::loadSramFrom(std::vector<u8>* buf)
 {
-	EMUFILE_MEMORY ms(buf);
-	MMU_new.backupDevice.load_movie(ms);
+	EMUFILE_MEMORY* ms = new EMUFILE_MEMORY(buf); // change to new to avoid automatic destruction
+	MMU_new.backupDevice.load_movie(*ms);
 	return true;
 }
 

--- a/desmume/src/movie.cpp
+++ b/desmume/src/movie.cpp
@@ -582,6 +582,8 @@ const char* _CDECL_ FCEUI_LoadMovie(const char *fname, bool _read_only, bool tas
 		bool success = MovieData::loadSramFrom(&currMovieData.sram);
 		if(!success) return "failed to load sram";
 	}
+	else
+		MMU_new.backupDevice.load_movie_blank();
 	freshMovie = true;
 	ClearAutoHold();
 


### PR DESCRIPTION
isMovieMode was removed because while playing a movie, the EMUFILE will always be an EMUFILE_MEMORY created for the movie, so there's no need to protect against overwriting the user's .dsv file on disk. (Writing to the EMUFILE must be allowed during movies to avoid getting an in-game error for not being able to write to the save file.)