### PR TITLE
revert to agg >= 2.4

### DIFF
--- a/desmume/src/frontend/modules/osd/agg/agg2d.h
+++ b/desmume/src/frontend/modules/osd/agg/agg2d.h
@@ -242,7 +242,6 @@ public:
 		BlendDstAtop    = agg::comp_op_dst_atop,
 		BlendXor        = agg::comp_op_xor,
 		BlendAdd        = agg::comp_op_plus,
-		BlendSub        = agg::comp_op_minus,
 		BlendMultiply   = agg::comp_op_multiply,
 		BlendScreen     = agg::comp_op_screen,
 		BlendOverlay    = agg::comp_op_overlay,
@@ -253,8 +252,7 @@ public:
 		BlendHardLight  = agg::comp_op_hard_light,
 		BlendSoftLight  = agg::comp_op_soft_light,
 		BlendDifference = agg::comp_op_difference,
-		BlendExclusion  = agg::comp_op_exclusion,
-		BlendContrast   = agg::comp_op_contrast
+		BlendExclusion  = agg::comp_op_exclusion
 	};
 
 	enum Direction

--- a/desmume/src/frontend/posix/configure.ac
+++ b/desmume/src/frontend/posix/configure.ac
@@ -205,7 +205,7 @@ if test ! "x$HAVE_OPENAL" = "xyes" ; then
 fi
 AM_CONDITIONAL([HAVE_ALSA], [test "${HAVE_ALSA}" = "yes"])
 
-PKG_CHECK_MODULES(LIBAGG, libagg >= 2.5.0, FOUND_LIBAGG=yes, FOUND_LIBAGG=no)
+PKG_CHECK_MODULES(LIBAGG, libagg >= 2.4.0, FOUND_LIBAGG=yes, FOUND_LIBAGG=no)
 AM_CONDITIONAL([HAVE_LIBAGG], [test "x$libagg" = "xyes" -a "${FOUND_LIBAGG}" = "yes"])
 if test "x$libagg" = "xyes" ; then
    if test "x$FOUND_LIBAGG" = "xyes" ; then


### PR DESCRIPTION
Upstream AGG version 2.5 is dead and the 2.4 version was forked and is developed seperatly at https://sourceforge.net/projects/agg/
Since this request just removes the enumeartions for new features in the discontinued AGG 2.5, which were never used in desmume, it should compile under both versions of AGG.