### PR TITLE
Pullreq/gdb stub

### DIFF
--- a/desmume/src/driver.h
+++ b/desmume/src/driver.h
@@ -107,7 +107,9 @@ public:
 	virtual bool EMU_HasEmulationStarted() { return true; }
 	virtual bool EMU_IsAtFrameBoundary() { return true; }
 	
+	virtual void EMU_DebugIdleEnter() {}
 	virtual void EMU_DebugIdleUpdate() {}
+	virtual void EMU_DebugIdleWakeUp() {}
 
 	enum eDebug_IOReg
 	{

--- a/desmume/src/frontend/posix/gtk-glade/Makefile.am
+++ b/desmume/src/frontend/posix/gtk-glade/Makefile.am
@@ -35,6 +35,3 @@ desmume_glade_LDADD = ../libdesmume.a \
 			$(SDL_LIBS) $(GTKGLEXT_LIBS) $(LIBGLADE_LIBS) \
 			$(GTHREAD_LIBS) $(ALSA_LIBS) $(LIBAGG_LIBS) \
 			$(LIBSOUNDTOUCH_LIBS)
-if HAVE_GDB_STUB
-desmume_glade_LDADD += ../gdbstub/libgdbstub.a
-endif

--- a/desmume/src/frontend/posix/gtk-glade/main.cpp
+++ b/desmume/src/frontend/posix/gtk-glade/main.cpp
@@ -33,7 +33,7 @@
 
 #ifdef GDB_STUB
 #include "../armcpu.h"
-#include "../gdbstub/gdbstub.h"
+#include "../gdbstub.h"
 #endif
 
 #ifdef GTKGLEXT_AVAILABLE


### PR DESCRIPTION
Fixes for building the posix frontends with --enable-gdb-stub.
The first patch fixes compilation errors in the glade frontend.
The second patch reverts an api change of the CommandLine class (created by the wifi merge) which breaks NDSSystem.cpp compilation if --enable-gdb-stub is enabled.