### PR TITLE
(Windows Frontend) Allow screen resizing in horizontal display layout.

### DIFF
--- a/desmume/src/frontend/windows/main.cpp
+++ b/desmume/src/frontend/windows/main.cpp
@@ -1952,6 +1952,11 @@ static void DD_DoDisplay()
 			DD_FillRect(ddraw.surface.primary,0,bottom,left,wr.bottom,RGB(0,0,128)); //bottomleft
 			DD_FillRect(ddraw.surface.primary,left,bottom,right,wr.bottom,RGB(255,0,255)); //bottomcenter
 			DD_FillRect(ddraw.surface.primary,right,bottom,wr.right,wr.bottom,RGB(0,255,255)); //bottomright
+			if (video.layout == 1)
+			{
+				DD_FillRect(ddraw.surface.primary, SubScreenRect.left, wr.top, wr.right, SubScreenRect.top, RGB(0, 0, 0)); //Top gap left when centering the resized screen
+				DD_FillRect(ddraw.surface.primary, SubScreenRect.left, SubScreenRect.bottom, wr.right, wr.bottom, RGB(0, 0, 0)); //Bottom gap left when centering the resized screen
+			}
 		}
 	}
 

--- a/desmume/src/frontend/windows/resource.h
+++ b/desmume/src/frontend/windows/resource.h
@@ -958,6 +958,12 @@
 #define IDM_RENDER_3XBRZ                40123
 #define IDM_RENDER_4XBRZ                40124
 #define IDM_RENDER_5XBRZ                40125
+#define IDC_SCR_RATIO_1p0               40143
+#define IDC_SCR_RATIO_1p1               40144
+#define IDC_SCR_RATIO_1p2               40145
+#define IDC_SCR_RATIO_1p3               40146
+#define IDC_SCR_RATIO_1p4               40147
+#define IDC_SCR_RATIO_1p5               40148
 #define ID_LABEL_HK3b                   44670
 #define ID_LABEL_HK3c                   44671
 #define ID_LABEL_HK3d                   44672
@@ -1072,7 +1078,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NO_MFC                     1
 #define _APS_NEXT_RESOURCE_VALUE        128
-#define _APS_NEXT_COMMAND_VALUE         40126
+#define _APS_NEXT_COMMAND_VALUE         40149
 #define _APS_NEXT_CONTROL_VALUE         1065
 #define _APS_NEXT_SYMED_VALUE           101
 #endif

--- a/desmume/src/frontend/windows/resource.h
+++ b/desmume/src/frontend/windows/resource.h
@@ -964,6 +964,7 @@
 #define IDC_SCR_RATIO_1p3               40146
 #define IDC_SCR_RATIO_1p4               40147
 #define IDC_SCR_RATIO_1p5               40148
+#define IDC_SCR_VCENTER                 40149
 #define ID_LABEL_HK3b                   44670
 #define ID_LABEL_HK3c                   44671
 #define ID_LABEL_HK3d                   44672
@@ -1078,7 +1079,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NO_MFC                     1
 #define _APS_NEXT_RESOURCE_VALUE        128
-#define _APS_NEXT_COMMAND_VALUE         40149
+#define _APS_NEXT_COMMAND_VALUE         40150
 #define _APS_NEXT_CONTROL_VALUE         1065
 #define _APS_NEXT_SYMED_VALUE           101
 #endif

--- a/desmume/src/frontend/windows/resources.rc
+++ b/desmume/src/frontend/windows/resources.rc
@@ -1609,6 +1609,15 @@ BEGIN
             MENUITEM "&Always On Top",              IDM_ALWAYS_ON_TOP
             MENUITEM "&Lockdown",                   IDM_LOCKDOWN
         END
+        POPUP "Screen Size Ratio (L:R)"
+        BEGIN
+            MENUITEM "1.0 : 1.0",                   IDC_SCR_RATIO_1p0
+            MENUITEM "1.1 : 0.9",                   IDC_SCR_RATIO_1p1
+            MENUITEM "1.2 : 0.8",                   IDC_SCR_RATIO_1p2
+            MENUITEM "1.3 : 0.7",                   IDC_SCR_RATIO_1p3
+            MENUITEM "1.4 : 0.6",                   IDC_SCR_RATIO_1p4
+            MENUITEM "1.5 : 0.5",                   IDC_SCR_RATIO_1p5
+        END
         POPUP "Screen &Gap"
         BEGIN
             MENUITEM "&None\t(0 px)",               IDM_SCREENSEP_NONE

--- a/desmume/src/frontend/windows/resources.rc
+++ b/desmume/src/frontend/windows/resources.rc
@@ -1617,6 +1617,8 @@ BEGIN
             MENUITEM "1.3 : 0.7",                   IDC_SCR_RATIO_1p3
             MENUITEM "1.4 : 0.6",                   IDC_SCR_RATIO_1p4
             MENUITEM "1.5 : 0.5",                   IDC_SCR_RATIO_1p5
+            MENUITEM SEPARATOR
+            MENUITEM "Center Vertically",           IDC_SCR_VCENTER
         END
         POPUP "Screen &Gap"
         BEGIN


### PR DESCRIPTION
The right hand screen is allowed to be resized in horizontal screen layout to enable the window or full screen display to better utilize the screen area.

Changes:
1- Modify scaling, resizing and update functions to allow for new screen resizing ratio
2- Modify touch input scaling (incl. HUD editing) to adapt to different screen sizes
3- Add GUI menu for user to select the screen resizing ratio
4- Implement saving/loading settings from file similar to other settings