### PR TITLE
(Windows Frontend) Fix window size increase on startup

### DIFF
--- a/desmume/src/frontend/windows/main.cpp
+++ b/desmume/src/frontend/windows/main.cpp
@@ -675,7 +675,7 @@ void ScaleScreen(float factor, bool user)
 		else
 			if (video.layout == 1)
 			{
-				w1x = video.rotatedwidthgap() * 2;
+				w1x = video.rotatedwidthgap() * 2 / screenSizeRatio;
 				h1x = video.rotatedheightgap() / 2;
 			}
 			else


### PR DESCRIPTION
Fix missing division in ScaleScreen function which caused window size to increase on each startup  if screen size ratio > 1.