### PR TITLE
(Windows Frontend) Add Fullscreen Options And Window Sizing Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.user
 *.suo
 *.VC.db
+*.VC.opendb
 *.o
 .deps
 *.dirstamp

--- a/desmume/src/frontend/windows/hotkey.cpp
+++ b/desmume/src/frontend/windows/hotkey.cpp
@@ -347,12 +347,10 @@ void HK_AutoHoldClearKeyDown(int, bool justPressed) {
 }
 
 extern VideoInfo video;
-extern void doLCDsLayout();
+extern void doLCDsLayout(int videoLayout);
 void HK_LCDsMode(int)
 {
-	video.layout++;
-	if (video.layout > 2) video.layout = 0;
-	doLCDsLayout();
+	doLCDsLayout(video.layout + 1);
 }
 
 extern void LCDsSwap(int);

--- a/desmume/src/frontend/windows/main.cpp
+++ b/desmume/src/frontend/windows/main.cpp
@@ -5232,6 +5232,8 @@ DOKEYDOWN:
 		if(wParam != VK_PAUSE)
 			break;
 	case WM_SYSKEYUP:
+		if (wParam == VK_MENU && GetMenu(hwnd) == NULL)
+			return 0;
 	case WM_CUSTKEYUP:
 		{
 			int modifiers = GetModifiers(wParam);

--- a/desmume/src/frontend/windows/main.h
+++ b/desmume/src/frontend/windows/main.h
@@ -47,6 +47,11 @@ void WavEnd();
 void UpdateToolWindows();
 bool DemandLua();
 void SetRotate(HWND hwnd, int rot, bool user = true);
+void SaveWindowPos(HWND hwnd);
+void SaveWindowSize(HWND hwnd);
+void SaveWindowSizePos(HWND hwnd);
+void RestoreWindow(HWND hwnd);
+void ShowFullScreen(HWND hwnd);
 
 extern bool frameCounterDisplay;
 extern bool FpsDisplay;

--- a/desmume/src/frontend/windows/resource.h
+++ b/desmume/src/frontend/windows/resource.h
@@ -967,6 +967,9 @@
 #define IDC_SCR_RATIO_1p4               40147
 #define IDC_SCR_RATIO_1p5               40148
 #define IDC_SCR_VCENTER                 40149
+#define IDM_FS_MENU                     40150
+#define IDM_FS_WINDOW                   40151
+#define IDM_FS_HIDE_CURSOR              40152
 #define ID_LABEL_HK3b                   44670
 #define ID_LABEL_HK3c                   44671
 #define ID_LABEL_HK3d                   44672
@@ -1081,7 +1084,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NO_MFC                     1
 #define _APS_NEXT_RESOURCE_VALUE        128
-#define _APS_NEXT_COMMAND_VALUE         40150
+#define _APS_NEXT_COMMAND_VALUE         40153
 #define _APS_NEXT_CONTROL_VALUE         1066
 #define _APS_NEXT_SYMED_VALUE           101
 #endif

--- a/desmume/src/frontend/windows/resources.rc
+++ b/desmume/src/frontend/windows/resources.rc
@@ -1637,7 +1637,7 @@ BEGIN
         END
         POPUP "Fullscreen Options"
         BEGIN
-            MENUITEM "Non-exclusive Mode",          IDM_FS_WINDOW
+            MENUITEM "Force Windowed Fullscreen",   IDM_FS_WINDOW
             MENUITEM "Show Menu",                   IDM_FS_MENU
             MENUITEM "Auto-Hide Cursor",            IDM_FS_HIDE_CURSOR
         END

--- a/desmume/src/frontend/windows/resources.rc
+++ b/desmume/src/frontend/windows/resources.rc
@@ -1635,6 +1635,12 @@ BEGIN
             MENUITEM "&Gray",                       IDM_SCREENSEP_COLORGRAY
             MENUITEM "&Black",                      IDM_SCREENSEP_COLORBLACK
         END
+        POPUP "Fullscreen Options"
+        BEGIN
+            MENUITEM "Non-exclusive Mode",          IDM_FS_WINDOW
+            MENUITEM "Show Menu",                   IDM_FS_MENU
+            MENUITEM "Auto-Hide Cursor",            IDM_FS_HIDE_CURSOR
+        END
         POPUP "Magnification &Filter"
         BEGIN
             MENUITEM "Normal",                      IDM_RENDER_NORMAL


### PR DESCRIPTION
Added the following Options:
1- Windowed Fullscreen mode (fixes #164), assuming user turns off vsync option in desmume as DWM will handle that
2- Show menu in full screen mode, and fixed settings changes (from menu or hotkey) that break window size
3- Auto-hide cursor option (Full screen mode)

Fixes:
1- Screen gap is no longer visible in horizontal layout when the window is resized when using opengl display method if the layout was changed from vertical to horizontal without restarting the emulator
2- No longer possible to rotate the video using hotkey in horizontal layout
3- Changing layout from vertical to horizontal while video is rotated and windowsize = 0 no longer increases window size
4- Changing screen layout while screensizeratio is > 1 and windowsize = 0 no longer increases window size
5- Repeatedly entering and exiting full screen mode while windowsize = 0 no longer increases window size
6- Pressing the menu key has no effect if the main window has no menu

Unrelated change: add *.VC.opendb to gitignore (generated by VS when solution is open)