### PR TITLE
Fix undefined behaviour converting 3D postest registers

### DIFF
--- a/desmume/src/gfx3d.cpp
+++ b/desmume/src/gfx3d.cpp
@@ -1946,7 +1946,7 @@ void gfx3d_glAlphaFunc(u32 v)
 
 u32 gfx3d_glGetPosRes(const size_t index)
 {
-	return (u32)(PTcoords[index] * 4096.0f);
+	return (u32)(s32)(PTcoords[index] * 4096.0f);
 }
 
 //#define _3D_LOG_EXEC


### PR DESCRIPTION
If the position test register is negative, conversion to unsigned
integer is undefined. This breaks games on arm64 where the behaviour is
defined as 'truncate to zero'. Converting to a signed integer first
guarantees the intended behaviour.