### PR TITLE
[Windows] Hide the console window in the current session when disabling in menu.

### DIFF
--- a/desmume/src/frontend/windows/console.cpp
+++ b/desmume/src/frontend/windows/console.cpp
@@ -208,6 +208,7 @@ void CloseConsole()
 		WritePrivateProfileInt("Console", "PosY",	pos.top, IniName);
 		WritePrivateProfileInt("Console", "Width",	width, IniName);
 		WritePrivateProfileInt("Console", "Height",	height, IniName);
+		ShowWindow(gConsoleWnd, SW_HIDE); // FreeConsole isn't killing the console process in Windows 10 so just hide the window for now.
 	}
 
 	FreeConsole();


### PR DESCRIPTION
Currently under Windows 1803 and 1809 (maybe other windows versions as well), when disabling console, it will only detach from the Desmume process and continue to stay open and visible. Since I don't really know much about the console and how to fix it, we should just hide the window for now.