### PR TITLE
[Windows]Use 64bit linker as backup instead of failing to find

### DIFF
--- a/desmume/src/frontend/windows/DeSmuME.vcxproj
+++ b/desmume/src/frontend/windows/DeSmuME.vcxproj
@@ -58,6 +58,10 @@
     <Import Project="desmume.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ExecutablePath>$(VC_ExecutablePath_x64);$(VC_ExecutablePath_x64_x64);$(VC_ExecutablePath_x64_x86);$(WindowsSdk_71A_ExecutablePath);$(WindowsSDK_ExecutablePath);$(MSBuild_ExecutablePath);$(FxCopDir);$(PATH)</ExecutablePath>
+    <ExcludePath>$(VC_ExecutablePath_x64_x64);$(VC_ExecutablePath_x64_x86);$(ExcludePath)</ExcludePath>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Link>
       <LargeAddressAware>true</LargeAddressAware>


### PR DESCRIPTION
Recently appveyor and my own builds have been failing fairly often with "out of heap-space" type errors. It tries to find the 64bit linker but it's not configured to find it within the project.

I've only tested this with VS2017 and the output is created from within VS property manager so I'm not sure if it works on older compilers but I guess by submitting a PR it tests appveyor's vs2015.