### PR TITLE
Add shader declaration PFNGLBINDFRAGDATALOCATIONINDEXEDPROC.

### DIFF
--- a/desmume/src/OGLRender_3_2.cpp
+++ b/desmume/src/OGLRender_3_2.cpp
@@ -39,6 +39,7 @@ OGLEXT(PFNGLCLEARBUFFERFIPROC, glClearBufferfi) // Core in v3.0
 
 // Shaders
 OGLEXT(PFNGLBINDFRAGDATALOCATIONPROC, glBindFragDataLocation) // Core in v3.0
+OGLEXT(PFNGLBINDFRAGDATALOCATIONINDEXEDPROC, glBindFragDataLocationIndexed) // Core in v3.0
 
 // Buffer Objects
 OGLEXT(PFNGLMAPBUFFERRANGEPROC, glMapBufferRange) // Core in v3.0


### PR DESCRIPTION
Resolves:
```
../../OGLRender_3_2.cpp: In member function ‘virtual Render3DError OpenGLRenderer_3_2::CreateFogProgram(OGLFogProgramKey, const char*, const char*)’:
../../OGLRender_3_2.cpp:1916:3: error: ‘glBindFragDataLocationIndexed’ was not declared in this scope
   glBindFragDataLocationIndexed(shaderID.program, 0, 0, "outFogColor");
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../OGLRender_3_2.cpp:1916:3: note: suggested alternative: ‘glBindFragDataLocation’
   glBindFragDataLocationIndexed(shaderID.program, 0, 0, "outFogColor");
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   glBindFragDataLocation
```