### PR TITLE
Fix Action Replay DS code type 0x0E

### DIFF
--- a/desmume/src/cheatSystem.cpp
+++ b/desmume/src/cheatSystem.cpp
@@ -193,6 +193,14 @@ void CHEATS::ARparser(CHEATS_LIST& list)
 		}
 		if(type == 0xD0 || type == 0xD1 || type == 0xD2) {}
 		else if(type == 0xC5) {}
+		else if(type == 0x0E)
+		{
+			if (statusSkip) {
+				CHEATLOG(" (skip multiple lines!)\n");
+				i += (lo + 7) / 8;
+				continue;
+			}
+		}
 		else
 		{
 			if(statusSkip) {


### PR DESCRIPTION
This PR fixes a regression issue with the Action Replay DS cheat handler that was reintroduced when it was rewritten in 6abf2b3. Currently, the cheat handler does not skip over the extra lines of code type 0x0E (Patch Code) when execution status is _false_.

Consider the following ARDS code:
```
52000000 AAAAAAAA
E2000000 00000008
D2D2D2D2 D2D2D2D2
02000008 BBBBBBBB
D2000000 00000000
```
When the word at `0x02000000` does not equal `0xAAAAAAAA`, the cheat handler is supposed to skip over all following codes until a 0xD0 or 0xD2 code is encountered. But because the `0xD2D2D2D2` written by the 0x0E code is not skipped, the cheat handler interprets this as a 0xD2 code and resets execution status prematurely. As a result, the value `0xBBBBBBB` is written to `0x02000008` even though the condition does not hold.

This patch fixes the issue by adding a check for code type 0x0E when execution status is set to false, incrementing the line counter based on the number of bytes specified to be patched.