### PR TITLE
Clarify parameter names for gui.setlayermask

### DIFF
--- a/desmume/src/lua-engine.cpp
+++ b/desmume/src/lua-engine.cpp
@@ -3279,16 +3279,16 @@ DEFINE_LUA_FUNCTION(gui_settransparency, "transparency_4_to_0")
 	return 0;
 }
 
-// gui.setlayermask(int top, int bottom)
-// enables or disables display layers for each screen according to the bitfields provided
+// gui.setlayermask(int main, int sub)
+// enables or disables display layers for each GPU according to the bitfields provided
 // e.g. 31 (11111) shows all layers; 0 (00000) hides all layers; 16 (10000) shows only the object layer (layer 4)
 // this function is only supported by the windows frontend.
-DEFINE_LUA_FUNCTION(gui_setlayermask, "top,bottom")
+DEFINE_LUA_FUNCTION(gui_setlayermask, "main,sub")
 {
 #if defined(WIN32)
-	lua_Integer top = luaL_checkint(L, 1);
-	lua_Integer bottom = luaL_checkint(L, 2);
-	SetLayerMasks(top, bottom);
+	lua_Integer main = luaL_checkint(L, 1);
+	lua_Integer sub = luaL_checkint(L, 2);
+	SetLayerMasks(main, sub);
 #endif
 	return 0;
 }


### PR DESCRIPTION
This is a tiny follow-up to PR #273, with no actual changes in functionality. In short:

- `gui.setlayermask(top, bottom)` &rarr; `gui.setlayermask(main, sub)`

Display layers correspond to the GPU _(main or sub)_, not to screen _(top or bottom)_, so this change just updates the Lua parameter names to reflect that.

I wasn't aware of that discrepancy until I tested a bit more, and I didn't want to introduce screen/GPU confusion into the codebase. NRN thx dawg