### PR TITLE
Add the "Set audio volume" menu item

### DIFF
--- a/desmume/src/frontend/posix/gtk/config_opts.h
+++ b/desmume/src/frontend/posix/gtk/config_opts.h
@@ -67,4 +67,5 @@ OPT(multisampling, bool, false, Config, OpenGLMultisampling)
 OPT(audio_enabled, bool, true, Audio, Enabled)
 OPT(audio_sync, int, 0, Audio, Synchronization)
 OPT(audio_interpolation, int, 1, Audio, Interpolation)
+OPT(audio_volume, int, 128, Audio, Volume)
 

--- a/desmume/src/frontend/posix/shared/sndsdl.cpp
+++ b/desmume/src/frontend/posix/shared/sndsdl.cpp
@@ -57,6 +57,7 @@ static volatile u32 soundpos;
 static u32 soundlen;
 static u32 soundbufsize;
 static SDL_AudioSpec audiofmt;
+int audio_volume;
 
 //////////////////////////////////////////////////////////////////////////////
 #ifdef _XBOX
@@ -82,14 +83,17 @@ static void MixAudio(void *userdata, Uint8 *stream, int len) {
    int i;
    Uint8 *soundbuf=(Uint8 *)stereodata16;
 
+   Uint8 *stream_tmp=(Uint8 *)malloc(len);
    for (i = 0; i < len; i++)
    {
       if (soundpos >= soundbufsize)
          soundpos = 0;
 
-      stream[i] = soundbuf[soundpos];
+      stream_tmp[i] = soundbuf[soundpos];
       soundpos++;
    }
+   SDL_MixAudio(stream, stream_tmp, len, audio_volume);
+   free(stream_tmp);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -222,3 +226,11 @@ void SNDSDLSetVolume(int volume)
 }
 
 //////////////////////////////////////////////////////////////////////////////
+int SNDSDLGetAudioVolume()
+{
+   return audio_volume;
+}
+void SNDSDLSetAudioVolume(int value)
+{
+   audio_volume = value;
+}

--- a/desmume/src/frontend/posix/shared/sndsdl.h
+++ b/desmume/src/frontend/posix/shared/sndsdl.h
@@ -23,4 +23,7 @@
 #define SNDCORE_SDL 2
 
 extern SoundInterface_struct SNDSDL;
+extern int audio_volume;
+int SNDSDLGetAudioVolume();
+void SNDSDLSetAudioVolume(int value);
 #endif


### PR DESCRIPTION
This is a request to add the "Set audio volume" menu item to the posix GTK front end of desmume.
Go to "Config > Set audio volume" to set the audio volume.
A slider helps to set the audio volume between 0 and 128.
This feature is already included in a lot of emulators like fceux (Nintendo Entertainment System) or visualboyadvance-m (Nintendo Game Boy) so I think it makes sense for desmume (Nintendo DS) to do it too.
Moreover, this new menu item will let the user set the audio volume directly inside desmume without using an external mixer included in the operating system.
This is more straightforward.

* desmume/src/frontend/posix/gtk/config_opts.h: Add the "audio_volume" option.
* desmume/src/frontend/posix/gtk/main.cpp: Add the "setaudiovolume" menu item.
* desmume/src/frontend/posix/gtk/main.cpp: Add the "setaudiovolume" action entry.
* desmume/src/frontend/posix/gtk/main.cpp(SetAudioVolume): Add this function.
* desmume/src/frontend/posix/gtk/main.cpp(CallbackSetAudioVolume): Add this function.
* desmume/src/frontend/posix/gtk/main.cpp(common_gtk_main): Add the "SNDSDLSetAudioVolume" function call.
* desmume/src/frontend/posix/shared/sndsdl.cpp: Add the "audio_volume" global variable.
* desmume/src/frontend/posix/shared/sndsdl.cpp(MixAudio): Add the "SDL_MixAudio" function call.
* desmume/src/frontend/posix/shared/sndsdl.cpp(SNDSDLGetAudioVolume): Add this function.
* desmume/src/frontend/posix/shared/sndsdl.cpp(SNDSDLSetAudioVolume): Add this function.
* desmume/src/frontend/posix/shared/sndsdl.h: Add the "audio_volume" global variable.
* desmume/src/frontend/posix/shared/sndsdl.h(SNDSDLGetAudioVolume): Add this function.
* desmume/src/frontend/posix/shared/sndsdl.h(SNDSDLSetAudioVolume): Add this function.