### PR TITLE
Add the "Set firmware language" menu item

### DIFF
--- a/desmume/src/frontend/posix/gtk/config_opts.h
+++ b/desmume/src/frontend/posix/gtk/config_opts.h
@@ -62,6 +62,8 @@ OPT(textureSmoothing, bool, false, Config, 3DTextureSmoothing)
 OPT(textureUpscale, int, 1, Config, 3DTextureUpscaling)
 OPT(highColorInterpolation, bool, true, Config, HighResolutionColorInterpolation)
 OPT(multisampling, bool, false, Config, OpenGLMultisampling)
+OPT(command_line_overriding_firmware_language, bool, false, Config, CommandLineOverridingFirmwareLanguage)
+OPT(firmware_language, int, 1, Config, FirmwareLanguage)
 
 /* Audio */
 OPT(audio_enabled, bool, true, Audio, Enabled)


### PR DESCRIPTION
This is a request to add the "Set firmware language" menu item to the posix GTK front end of desmume.
Go to "Config > Set firmware language" to set the firmware language.
Here, check the checkbox to enable the command line overriding.
After that, you can choose the firmware language through a combo box.

Desmume already offers to set the firmware language on the command line.
For example, you can set the french language:
```
$ desmume --lang 2
```
However, having a menu item to set the firmware language is more user-friendly.
For those who like specifying the firmware language on the command line, it is not a problem because it is always possible and it is the default.

* desmume/src/frontend/posix/gtk/config_opts.h: Add the "command_line_overriding_firmware_language" option.
* desmume/src/frontend/posix/gtk/config_opts.h: Add the "firmware_language" option.
* desmume/src/frontend/posix/gtk/main.cpp: Add the "setfirmwarelanguage" menu item.
* desmume/src/frontend/posix/gtk/main.cpp: Add the "setfirmwarelanguage" action entry.
* desmume/src/frontend/posix/gtk/main.cpp(CallbackSetAudioVolume): Fix its parameters ("*" attached to the name rather than the type).
* desmume/src/frontend/posix/gtk/main.cpp(SetAudioVolume): Fix its indentation (spaces replaced by a tab).
* desmume/src/frontend/posix/gtk/main.cpp(SetFirmwareLanguage): Add this function.
* desmume/src/frontend/posix/gtk/main.cpp(CallbackSetFirmwareLanguage): Add this function.
* desmume/src/frontend/posix/gtk/main.cpp(common_gtk_main): If the command line overriding is enabled, then use the language set on the GUI.