### PR TITLE
GTK: add Auto pause in background option

### DIFF
--- a/desmume/src/frontend/posix/gtk/config_opts.h
+++ b/desmume/src/frontend/posix/gtk/config_opts.h
@@ -40,6 +40,7 @@ OPT(window_scale, int, 0, Window, Scale2x)
 /*OPT(window_h, int, 0, Window, Height)*/
 /*OPT(window_maximized, bool, false, Window, Maximized)*/
 OPT(window_fullscreen, bool, false, Window, Fullscreen)
+OPT(window_autoPause, bool, false, Window, AutoPause)
 
 /* HUD display */
 OPT(hud_fps, bool, false, HudDisplay, Fps)


### PR DESCRIPTION
Add option to automatically pause emulation when the main window loses focus for the GTK frontend.

The option is disabled by default, and can be enabled in `Config > Auto pause in background`. It is persisted in the config as `[Window] > AutoPause`.

Receiving focus will only resume the emulation if it was stopped automatically, so manually pausing will not be undone unintentionally.