### PR TITLE
Fix to compile with gcc

### DIFF
--- a/desmume/src/wifi.cpp
+++ b/desmume/src/wifi.cpp
@@ -37,6 +37,7 @@
 	#endif
 	#define PCAP_DEVICE_NAME description
 #else
+	#include <stddef.h>
 	#include <unistd.h>
 	#include <stdlib.h>
 	#include <string.h>


### PR DESCRIPTION
Tiny fix to include _offsetof_ inbuilt declaration to compile with modern gcc.