### PR TITLE
set fullscreen background to black for gtk frontend

### DIFF
--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -899,6 +899,9 @@ static void ToggleFullscreen(GtkToggleAction *action)
   config.window_fullscreen = gtk_toggle_action_get_active(action);
   if (config.window_fullscreen)
   {
+    GdkColor black = {0, 0, 0, 0};
+    gtk_widget_modify_bg(pDrawingArea, GTK_STATE_NORMAL, &black);
+
     gtk_widget_hide(pMenuBar);
     gtk_widget_hide(pToolBar);
     gtk_widget_hide(pStatusBar);
@@ -909,6 +912,8 @@ static void ToggleFullscreen(GtkToggleAction *action)
   }
   else
   {
+    gtk_widget_modify_bg(pDrawingArea, GTK_STATE_NORMAL, NULL);
+
     if (config.view_menu) {
       gtk_widget_show(pMenuBar);
     }


### PR DESCRIPTION
Fixes #309 by setting the background color to black when enabling fullscreen and setting it back to the default color when returning to window mode.