### PR TITLE
Issue: can't compile on Arch Linux #304

### DIFF
--- a/desmume/src/frontend/posix/cli/main.cpp
+++ b/desmume/src/frontend/posix/cli/main.cpp
@@ -568,10 +568,6 @@ int main(int argc, char ** argv) {
     slot2_Init();
     slot2_Change((NDS_SLOT2_TYPE)slot2_device_type);
 
-#if !g_thread_supported()
-    g_thread_init( NULL);
-#endif
-
   driver = new BaseDriver();
   
 #ifdef GDB_STUB

--- a/desmume/src/frontend/posix/gtk-glade/main.cpp
+++ b/desmume/src/frontend/posix/gtk-glade/main.cpp
@@ -334,10 +334,8 @@ gchar * get_ui_file (const char *filename)
 void *
 createThread_gdb( void (*thread_function)( void *data),
                   void *thread_data) {
-  GThread *new_thread = g_thread_create( (GThreadFunc)thread_function,
-                                         thread_data,
-                                         TRUE,
-                                         NULL);
+  GThread *new_thread = g_thread_new(NULL, (GThreadFunc)thread_function,
+                                     thread_data);
 
   return new_thread;
 }
@@ -530,10 +528,6 @@ int main(int argc, char *argv[]) {
     {
       fprintf(stderr, "Warning: X11 not thread-safe\n");
     }
-
-#if !g_thread_supported()
-  g_thread_init( NULL);
-#endif
 
   gtk_init(&argc, &argv);
 

--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -789,10 +789,9 @@ void *
 createThread_gdb( void (*thread_function)( void *data),
                   void *thread_data)
 {
-  GThread *new_thread = g_thread_create( (GThreadFunc)thread_function,
-                                         thread_data,
-                                         TRUE,
-                                         NULL);
+  GThread *new_thread = g_thread_new(NULL,
+                                     (GThreadFunc)thread_function,
+                                     thread_data);
 
   return new_thread;
 }
@@ -3611,10 +3610,6 @@ int main (int argc, char *argv[])
     {
       fprintf(stderr, "Warning: X11 not thread-safe\n");
     }
-
-#if !g_thread_supported()
-    g_thread_init( NULL);
-#endif
 
   gtk_init(&argc, &argv);
 


### PR DESCRIPTION
The build failure(s) come from the fact that the posix frontends currently
use deprecated functions for multi-threading. The offending functions are:
g_thread_create and g_thread_supported, both deprecated since 2.32.

This patch fixes issue #304 by replacing g_thread_create with g_thread_new.
g_thread_supported is removed as it's no longer needed at all for glib >= 2.32
threading is automatically initialized when the program starts.
