### PR TITLE
Fix glade UI file path in local builds

### DIFF
--- a/desmume/src/frontend/posix/configure.ac
+++ b/desmume/src/frontend/posix/configure.ac
@@ -174,7 +174,7 @@ if test "x$glade" = "xyes" ; then
     AC_SUBST(LIBGLADE_LIBS)
 
     dnl uninstalled glade ui dir
-    AC_DEFINE_UNQUOTED(GLADEUI_UNINSTALLED_DIR,"`pwd`/src/gtk-glade/glade/",[path to glade ui dir])
+    AC_DEFINE_UNQUOTED(GLADEUI_UNINSTALLED_DIR,"`pwd`/gtk-glade/glade/",[path to glade ui dir])
     AC_SUBST(GLADEUI_UNINSTALLED_DIR)
 
     PKG_CHECK_MODULES(GTKGLEXT,

--- a/desmume/src/frontend/posix/gtk-glade/main.cpp
+++ b/desmume/src/frontend/posix/gtk-glade/main.cpp
@@ -322,6 +322,8 @@ gchar * get_ui_file (const char *filename)
 	if (g_file_test (path, G_FILE_TEST_IS_REGULAR)) return path;
 	g_free (path);
 	
+	printf ("Failed to find ui file, \"%s\", in %s or %s\n",
+		filename ? filename : "", GLADEUI_UNINSTALLED_DIR, DATADIR);
 	/* not found */
 	return NULL;
 }


### PR DESCRIPTION
Update `GLADEUI_UNINSTALLED_DIR` to work with the current directory layout.

Also adds a failure message when the glade ui file is not found.