### PR TITLE
Fix unhandled null causing crash when using osmesa with nvidia driver

### DIFF
--- a/desmume/src/OGLRender_3_2.cpp
+++ b/desmume/src/OGLRender_3_2.cpp
@@ -2033,8 +2033,11 @@ void OpenGLRenderer_3_2::GetExtensionSet(std::set<std::string> *oglExtensionSet)
 	glGetIntegerv(GL_NUM_EXTENSIONS, &extensionCount);
 	for (size_t i = 0; i < extensionCount; i++)
 	{
-		std::string extensionName = std::string((const char *)glGetStringi(GL_EXTENSIONS, i));
-		oglExtensionSet->insert(extensionName);
+		const char * extensionName = (const char *)glGetStringi(GL_EXTENSIONS, i);
+		if (extensionName == NULL) {
+			continue;
+		}
+		oglExtensionSet->insert(std::string(extensionName));
 	}
 }
 


### PR DESCRIPTION
Should fix #126 and #202 
I'm worried that this might hide errors because it silently ignores them if it can't read an extension name. Maybe it's better to crash or log that the value was null?