### PR TITLE
Linux GTK Port: Fix config for new MSAA options

### DIFF
--- a/desmume/src/frontend/posix/gtk/config_opts.h
+++ b/desmume/src/frontend/posix/gtk/config_opts.h
@@ -62,6 +62,7 @@ OPT(textureSmoothing, bool, false, Config, 3DTextureSmoothing)
 OPT(textureUpscale, int, 1, Config, 3DTextureUpscaling)
 OPT(highColorInterpolation, bool, true, Config, HighResolutionColorInterpolation)
 OPT(multisampling, bool, false, Config, OpenGLMultisampling)
+OPT(multisamplingSize, int, 0, Config, OpenGLMultisamplingSize)
 OPT(command_line_overriding_firmware_language, bool, false, Config, CommandLineOverridingFirmwareLanguage)
 OPT(firmware_language, int, 1, Config, FirmwareLanguage)
 

--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -2416,6 +2416,8 @@ static void GraphicsSettingsDialog() {
 		CommonSettings.GFX3D_HighResolutionInterpolateColor = config.highColorInterpolation = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(wHCInterpolate));
 #ifdef HAVE_OPENGL
 		int selectedMultisample = gtk_combo_box_get_active(GTK_COMBO_BOX(wMultisample));
+		config.multisamplingSize = multisampleSizes[selectedMultisample];
+		config.multisampling = selectedMultisample != 0;
 		CommonSettings.GFX3D_Renderer_MultisampleSize = multisampleSizes[selectedMultisample];
 #endif
     }
@@ -3528,7 +3530,9 @@ common_gtk_main( class configured_features *my_config)
 	}
 
     CommonSettings.GFX3D_HighResolutionInterpolateColor = config.highColorInterpolation;
-	CommonSettings.GFX3D_Renderer_MultisampleSize = (config.multisampling) ? 4 : 0;
+	CommonSettings.GFX3D_Renderer_MultisampleSize = (config.multisamplingSize > 0)
+														? config.multisamplingSize
+														: config.multisampling ? 4 : 0;
     CommonSettings.GFX3D_Renderer_TextureDeposterize = config.textureDeposterize;
     CommonSettings.GFX3D_Renderer_TextureScalingFactor = (config.textureUpscale == 1 ||
     														config.textureUpscale == 2 ||


### PR DESCRIPTION
a289055e removed the code that updated the old "multisampling enabled"
config. This fix adds a new config value for the multisampling size and
updates the old config in sync. When loading the config, the new
multisampling size value is prioritized, but if it is 0 (possibly not set)
then it falls back to the previous logic using the old boolean config
value.