### PR TITLE
Fix directory crawling on symlink-capable systems

### DIFF
--- a/desmume/src/utils/vfat.cpp
+++ b/desmume/src/utils/vfat.cpp
@@ -69,7 +69,7 @@ static void list_files(const char *filepath, ListCallback list_callback)
 		list_callback(rdir,EListCallbackArg_Item);
 		printf("cflash added %s\n",fname);
 
-		if (retro_dirent_is_dir(rdir, filepath) && (strcmp(fname, ".")) && strcmp(fname, ".."))
+		if (retro_dirent_is_dir(rdir, fname) && (strcmp(fname, ".")) && strcmp(fname, ".."))
 		{
 			std::string subdir = (std::string)filepath + path_default_slash() + fname;
 			list_files(subdir.c_str(), list_callback);


### PR DESCRIPTION
Checking whether the current directory is a directory (instead of current entry) may lead to "pop" command issued on an empty stack, which in turn SEGV desmume.