### PR TITLE
Give thread names to ease debugging

### DIFF
--- a/desmume/src/GPU.cpp
+++ b/desmume/src/GPU.cpp
@@ -1414,7 +1414,7 @@ GPUEngineBase::GPUEngineBase()
 	if (CommonSettings.num_cores > 1)
 	{
 		_asyncClearTask = new Task;
-		_asyncClearTask->start(false);
+		_asyncClearTask->start(false, 0, "async clear");
 	}
 	else
 	{
@@ -8717,7 +8717,7 @@ GPUSubsystem::GPUSubsystem()
 	if (CommonSettings.num_cores > 1)
 	{
 		_asyncEngineBufferSetupTask = new Task;
-		_asyncEngineBufferSetupTask->start(false);
+		_asyncEngineBufferSetupTask->start(false, 0, "setup gpu bufs");
 	}
 	else
 	{

--- a/desmume/src/filter/videofilter.cpp
+++ b/desmume/src/filter/videofilter.cpp
@@ -188,7 +188,9 @@ void VideoFilter::__InstanceInit(size_t srcWidth, size_t srcHeight, VideoFilterT
 		__vfThread[i].param.filterFunction = NULL;
 		
 		__vfThread[i].task = new Task;
-		__vfThread[i].task->start(false);
+		char name[16];
+		snprintf(name, 16, "video filter %d", i);
+		__vfThread[i].task->start(false, 0, name);
 	}
 	
 	__vfFunc = _vfAttributes.filterFunction;

--- a/desmume/src/libretro-common/include/rthreads/rthreads.h
+++ b/desmume/src/libretro-common/include/rthreads/rthreads.h
@@ -87,8 +87,6 @@ int sthread_detach(sthread_t *thread);
  * @thread to terminate. If that thread has already terminated, then
  * it will return immediately. The thread specified by @thread must
  * be joinable.
- * 
- * Returns: 0 on success, otherwise it returns a non-zero error number.
  */
 void sthread_join(sthread_t *thread);
 

--- a/desmume/src/libretro-common/include/rthreads/rthreads.h
+++ b/desmume/src/libretro-common/include/rthreads/rthreads.h
@@ -104,6 +104,16 @@ void sthread_join(sthread_t *thread);
 bool sthread_isself(sthread_t *thread);
 
 /**
+ * sthread_set_name:
+ * @thread                  : pointer to thread object
+ * @name                    : name to define for the thread (at most
+ *                            15 bytes)
+ *
+ * Set the thread name, useful for debugging.
+ */
+void sthread_setname(sthread_t *thread, const char *name);
+
+/**
  * slock_new:
  *
  * Create and initialize a new mutex. Must be manually

--- a/desmume/src/libretro-common/rthreads/rthreads.c
+++ b/desmume/src/libretro-common/rthreads/rthreads.c
@@ -270,8 +270,6 @@ int sthread_detach(sthread_t *thread)
  * @thread to terminate. If that thread has already terminated, then
  * it will return immediately. The thread specified by @thread must
  * be joinable.
- *
- * Returns: 0 on success, otherwise it returns a non-zero error number.
  */
 void sthread_join(sthread_t *thread)
 {

--- a/desmume/src/libretro-common/rthreads/rthreads.c
+++ b/desmume/src/libretro-common/rthreads/rthreads.c
@@ -303,6 +303,24 @@ bool sthread_isself(sthread_t *thread)
 }
 
 /**
+ * sthread_set_name:
+ * @thread                  : pointer to thread object
+ * @name                    : name to define for the thread (at most
+ *                            15 bytes)
+ *
+ * Set the thread name, useful for debugging.
+ */
+void sthread_setname(sthread_t *thread, const char *name)
+{
+   if (!thread)
+      return;
+   // TODO: implement that for Windows too.
+#ifndef USE_WIN32_THREADS
+   pthread_setname_np(thread->id, name);
+#endif
+}
+
+/**
  * slock_new:
  *
  * Create and initialize a new mutex. Must be manually

--- a/desmume/src/rasterize.cpp
+++ b/desmume/src/rasterize.cpp
@@ -1802,7 +1802,9 @@ SoftRasterizerRenderer::SoftRasterizerRenderer()
 			// to help stabilize performance when running SoftRasterizer.
 			_task[i].start(false, 43);
 #else
-			_task[i].start(false);
+			char name[16];
+			snprintf(name, 16, "rasterizer %d", i);
+			_task[i].start(false, 0, name);
 #endif
 		}
 	}

--- a/desmume/src/utils/task.cpp
+++ b/desmume/src/utils/task.cpp
@@ -30,7 +30,7 @@ public:
 	Impl();
 	~Impl();
 
-	void start(bool spinlock, int threadPriority);
+	void start(bool spinlock, int threadPriority, const char *name);
 	void execute(const TWork &work, void *param);
 	void* finish();
 	void shutdown();
@@ -87,7 +87,7 @@ Task::Impl::~Impl()
 	scond_free(condWork);
 }
 
-void Task::Impl::start(bool spinlock, int threadPriority)
+void Task::Impl::start(bool spinlock, int threadPriority, const char *name)
 {
 	slock_lock(this->mutex);
 	
@@ -102,6 +102,8 @@ void Task::Impl::start(bool spinlock, int threadPriority)
 	this->exitThread = false;
 	this->_thread = sthread_create_with_priority(&taskProc, this, threadPriority);
 	this->_isThreadRunning = true;
+	if (name)
+		sthread_setname(this->_thread, name);
 	
 	slock_unlock(this->mutex);
 }
@@ -168,8 +170,8 @@ void Task::Impl::shutdown()
 	slock_unlock(this->mutex);
 }
 
-void Task::start(bool spinlock) { impl->start(spinlock, 0); }
-void Task::start(bool spinlock, int threadPriority) { impl->start(spinlock, threadPriority); }
+void Task::start(bool spinlock) { impl->start(spinlock, 0, nullptr); }
+void Task::start(bool spinlock, int threadPriority, const char *name) { impl->start(spinlock, threadPriority, name); }
 void Task::shutdown() { impl->shutdown(); }
 Task::Task() : impl(new Task::Impl()) {}
 Task::~Task() { delete impl; }

--- a/desmume/src/utils/task.h
+++ b/desmume/src/utils/task.h
@@ -30,7 +30,7 @@ public:
 
 	// initialize task runner
 	void start(bool spinlock);
-	void start(bool spinlock, int threadPriority);
+	void start(bool spinlock, int threadPriority, const char *name = nullptr);
 
 	//execute some work
 	void execute(const TWork &work, void* param);

--- a/desmume/src/wifi.cpp
+++ b/desmume/src/wifi.cpp
@@ -3398,7 +3398,7 @@ bool AdhocCommInterface::Start(WifiHandler* currentWifiHandler)
 	#ifdef DESMUME_COCOA
 	this->_rxTask->start(false, 43);
 	#else
-	this->_rxTask->start(false);
+	this->_rxTask->start(false, 0, "wifi ad-hoc");
 	#endif
 	this->_isRXThreadRunning = true;
 	this->_rxTask->execute(&Adhoc_RXPacketGetOnThread, this);
@@ -3672,7 +3672,7 @@ bool SoftAPCommInterface::Start(WifiHandler* currentWifiHandler)
 		#ifdef DESMUME_COCOA
 		this->_rxTask->start(false, 43);
 		#else
-		this->_rxTask->start(false);
+		this->_rxTask->start(false, 0, "wifi ap");
 		#endif
 		this->_isRXThreadRunning = true;
 		this->_rxTask->execute(&Infrastructure_RXPacketGetOnThread, this);


### PR DESCRIPTION
This makes it much more easy to figure out why a given thread is consuming CPU time for instance.

This is still missing sound threads, but those depend on SDL apparently.