### PR TITLE
GTK: Fix opening a ROM from the command line

### DIFF
--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -4444,6 +4444,18 @@ static void Teardown() {
 #endif
 }
 
+static void
+handle_open(GApplication *application,
+            GFile **files,
+            gint n_files,
+            const gchar *hint,
+            gpointer user_data)
+{
+    configured_features *my_config = static_cast<configured_features*>(user_data);
+    my_config->nds_file = g_file_get_path(files[0]);
+    common_gtk_main(application, user_data);
+}
+
 int main (int argc, char *argv[])
 {
   configured_features my_config;
@@ -4462,8 +4474,9 @@ int main (int argc, char *argv[])
     }
 
   // TODO: pass G_APPLICATION_HANDLES_COMMAND_LINE instead.
-  GtkApplication *app = gtk_application_new("org.desmume.DeSmuME", G_APPLICATION_FLAGS_NONE);
+  GtkApplication *app = gtk_application_new("org.desmume.DeSmuME", G_APPLICATION_HANDLES_OPEN);
   g_signal_connect (app, "activate", G_CALLBACK(common_gtk_main), &my_config);
+  g_signal_connect (app, "open", G_CALLBACK(handle_open), &my_config);
   g_action_map_add_action_entries(G_ACTION_MAP(app),
                                   app_entries, G_N_ELEMENTS(app_entries),
                                   app);


### PR DESCRIPTION
Only the first of the positional arguments is interpreted as the ROM’s filename, because we don’t emulate multiple ROMs at once.

Fixes #382.