### PR TITLE
gtk: add import/export memory menu items

### DIFF
--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -1882,6 +1882,11 @@ static void ExportBackupMemoryDialog(GSimpleAction *action, GVariant *parameter,
         GFile *file = gtk_file_chooser_get_file(GTK_FILE_CHOOSER(pFileSelection));
         gchar *sPath = g_file_get_path(file);
 
+        if(! g_str_has_suffix(sPath, ".sav"))
+        {
+            sPath = g_strjoin(NULL, sPath, ".sav", NULL);
+        }
+
         if(MMU_new.backupDevice.exportData(sPath) == false ) {
             GtkWidget *pDialog = gtk_message_dialog_new(GTK_WINDOW(pWindow),
                     GTK_DIALOG_MODAL,

--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -1822,7 +1822,7 @@ static void ImportBackupMemoryDialog(GSimpleAction *action, GVariant *parameter,
     pFileSelection = gtk_file_chooser_native_new("Import Backup Memory From ...",
             GTK_WINDOW(pWindow),
             GTK_FILE_CHOOSER_ACTION_OPEN,
-	    "_Open", "_Cancel");
+            "_Open", "_Cancel");
 
     /* Only the dialog window is accepting events: */
     gtk_window_set_modal(GTK_WINDOW(pFileSelection), TRUE);
@@ -1873,7 +1873,7 @@ static void ExportBackupMemoryDialog(GSimpleAction *action, GVariant *parameter,
     pFileSelection = gtk_file_chooser_native_new("Export Backup Memory To ...",
             GTK_WINDOW(pWindow),
             GTK_FILE_CHOOSER_ACTION_SAVE,
-	    "_Save", "_Cancel");
+            "_Save", "_Cancel");
     gtk_file_chooser_set_do_overwrite_confirmation (GTK_FILE_CHOOSER (pFileSelection), TRUE);
 
     /* Only the dialog window is accepting events: */
@@ -1885,7 +1885,7 @@ static void ExportBackupMemoryDialog(GSimpleAction *action, GVariant *parameter,
     /* Showing the window */
     int response = gtk_native_dialog_run(GTK_NATIVE_DIALOG(pFileSelection));
     if (response == GTK_RESPONSE_ACCEPT) {
-	GFile *file = gtk_file_chooser_get_file(GTK_FILE_CHOOSER(pFileSelection));
+        GFile *file = gtk_file_chooser_get_file(GTK_FILE_CHOOSER(pFileSelection));
         gchar *sPath = g_file_get_path(file);
 
         if(MMU_new.backupDevice.exportData(sPath) == false ) {

--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -1835,7 +1835,7 @@ static void ImportBackupMemoryDialog(GSimpleAction *action, GVariant *parameter,
         gchar *sPath = g_file_get_path(file);
 
         if(MMU_new.backupDevice.importData(sPath) == false ) {
-            GtkWidget *pDialog = gtk_message_dialog_new(GTK_WINDOW(pFileSelection),
+            GtkWidget *pDialog = gtk_message_dialog_new(GTK_WINDOW(pWindow),
                     GTK_DIALOG_MODAL,
                     GTK_MESSAGE_ERROR,
                     GTK_BUTTONS_OK,
@@ -1883,7 +1883,7 @@ static void ExportBackupMemoryDialog(GSimpleAction *action, GVariant *parameter,
         gchar *sPath = g_file_get_path(file);
 
         if(MMU_new.backupDevice.exportData(sPath) == false ) {
-            GtkWidget *pDialog = gtk_message_dialog_new(GTK_WINDOW(pFileSelection),
+            GtkWidget *pDialog = gtk_message_dialog_new(GTK_WINDOW(pWindow),
                     GTK_DIALOG_MODAL,
                     GTK_MESSAGE_ERROR,
                     GTK_BUTTONS_OK,

--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -1824,9 +1824,6 @@ static void ImportBackupMemoryDialog(GSimpleAction *action, GVariant *parameter,
             GTK_FILE_CHOOSER_ACTION_OPEN,
             "_Open", "_Cancel");
 
-    /* Only the dialog window is accepting events: */
-    gtk_window_set_modal(GTK_WINDOW(pFileSelection), TRUE);
-
     gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(pFileSelection), pFilter_raw);
     gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(pFileSelection), pFilter_ar);
     gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(pFileSelection), pFilter_any);
@@ -1875,9 +1872,6 @@ static void ExportBackupMemoryDialog(GSimpleAction *action, GVariant *parameter,
             GTK_FILE_CHOOSER_ACTION_SAVE,
             "_Save", "_Cancel");
     gtk_file_chooser_set_do_overwrite_confirmation (GTK_FILE_CHOOSER (pFileSelection), TRUE);
-
-    /* Only the dialog window is accepting events: */
-    gtk_window_set_modal(GTK_WINDOW(pFileSelection), TRUE);
 
     gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(pFileSelection), pFilter_raw);
     gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(pFileSelection), pFilter_any);

--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -1839,7 +1839,7 @@ static void ImportBackupMemoryDialog(GSimpleAction *action, GVariant *parameter,
                     GTK_DIALOG_MODAL,
                     GTK_MESSAGE_ERROR,
                     GTK_BUTTONS_OK,
-                    "Unable to import :\n%s", sPath);
+                    "Unable to import:\n%s", sPath);
             gtk_dialog_run(GTK_DIALOG(pDialog));
             gtk_widget_destroy(pDialog);
         }
@@ -1887,7 +1887,7 @@ static void ExportBackupMemoryDialog(GSimpleAction *action, GVariant *parameter,
                     GTK_DIALOG_MODAL,
                     GTK_MESSAGE_ERROR,
                     GTK_BUTTONS_OK,
-                    "Unable to export :\n%s", sPath);
+                    "Unable to export:\n%s", sPath);
             gtk_dialog_run(GTK_DIALOG(pDialog));
             gtk_widget_destroy(pDialog);
         }


### PR DESCRIPTION
This pull request is a rebase of https://github.com/TASVideos/desmume/pull/347 .  When I originally submitted this, there was a lot of recent changes to the gtk code in desmume.  I finally got around to rebasing this against the latest gtk changes in desmume

This branch adds "Import Backup Memory" and "Export Backup Memory" entries to the GTK File menu.  Previously, this functionality was only available on the win32 version.