### PR TITLE
GTK: Use standard meson to install man pages

### DIFF
--- a/desmume/src/frontend/posix/cli/meson.build
+++ b/desmume/src/frontend/posix/cli/meson.build
@@ -23,4 +23,4 @@ executable('desmume-cli',
   install: true,
 )
 
-install_data('doc/desmume-cli.1', install_dir: join_paths(get_option('datadir'), 'man', 'man1'))
+install_man('doc/desmume-cli.1')

--- a/desmume/src/frontend/posix/gtk-glade/meson.build
+++ b/desmume/src/frontend/posix/gtk-glade/meson.build
@@ -42,5 +42,5 @@ executable('desmume-glade',
 
 install_data('desmume-glade.desktop', install_dir: join_paths(get_option('datadir'), 'applications'))
 install_data('glade/DeSmuME.xpm', install_dir: join_paths(get_option('datadir'), 'pixmaps'))
-install_data('doc/desmume-glade.1', install_dir: join_paths(get_option('datadir'), 'man', 'man1'))
+install_man('doc/desmume-glade.1')
 install_data(['glade/DeSmuMe_Dtools.glade', 'glade/DeSmuMe.glade', 'glade/DeSmuME.xpm'], install_dir: join_paths(get_option('datadir'), 'glade'))

--- a/desmume/src/frontend/posix/gtk/meson.build
+++ b/desmume/src/frontend/posix/gtk/meson.build
@@ -38,4 +38,4 @@ executable('desmume',
 install_data('org.desmume.DeSmuME.desktop', install_dir: join_paths(get_option('datadir'), 'applications'))
 install_data('org.desmume.DeSmuME.metainfo.xml', install_dir: join_paths(get_option('datadir'), 'metainfo'))
 install_data('org.desmume.DeSmuME.svg', install_dir: join_paths(get_option('datadir'), 'icons', 'hicolor', 'scalable', 'apps'))
-install_data('doc/desmume.1', install_dir: join_paths(get_option('datadir'), 'man', 'man1'))
+install_man('doc/desmume.1')


### PR DESCRIPTION
Use standard function `install_man` which automatically determines the mandir and `man[0-9]` instead of guessing. Now it respects the `--mandir` option.

By default it's set to `--mandir=share/man`, which is where it was installing.