### PR TITLE
GTK: fix GL context creation with prime render offload (nvidia)

### DIFF
--- a/desmume/src/frontend/posix/gtk/sdl_3Demu.cpp
+++ b/desmume/src/frontend/posix/gtk/sdl_3Demu.cpp
@@ -49,30 +49,34 @@ bool deinit_sdl_3Demu(void)
 
 bool init_sdl_3Demu(void) 
 {
-    win = SDL_CreateWindow(NULL, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, 256, 192, SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN);
-    if (!win)
-        return false;
-
+    SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8);
+    SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
+    SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8);
+    SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
     SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
 
+    win = SDL_CreateWindow(NULL, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, 256, 192, SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN);
+    if (!win)
+        return false;
+
     ctx = SDL_GL_CreateContext(win);
     if (!ctx)
-	{
+    {
         printf("Failed to create GL context: %s\n", SDL_GetError());
-		return false;
-	}
-	
-	int v[5];
-	SDL_GL_GetAttribute(SDL_GL_RED_SIZE, v);
+            return false;
+    }
+
+    int v[5];
+    SDL_GL_GetAttribute(SDL_GL_RED_SIZE, v);
     SDL_GL_GetAttribute(SDL_GL_GREEN_SIZE, v+1);
     SDL_GL_GetAttribute(SDL_GL_BLUE_SIZE, v+2);
     SDL_GL_GetAttribute(SDL_GL_ALPHA_SIZE, v+3);
     SDL_GL_GetAttribute(SDL_GL_DEPTH_SIZE, v+4);
-	printf("GL buffer format: R=%d G=%d B=%d A=%d D=%d\n", v[0], v[1], v[2], v[3], v[4]);
+    printf("GL buffer format: R=%d G=%d B=%d A=%d D=%d\n", v[0], v[1], v[2], v[3], v[4]);
 
     printf("OGL/SDL Renderer has finished the initialization.\n");
 

--- a/desmume/src/frontend/posix/gtk/sdl_3Demu.cpp
+++ b/desmume/src/frontend/posix/gtk/sdl_3Demu.cpp
@@ -53,6 +53,7 @@ bool init_sdl_3Demu(void)
     SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
     SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8);
     SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
+	SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
     SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);

--- a/desmume/src/frontend/posix/gtk/sdl_3Demu.cpp
+++ b/desmume/src/frontend/posix/gtk/sdl_3Demu.cpp
@@ -53,11 +53,6 @@ bool init_sdl_3Demu(void)
     if (!win)
         return false;
 
-    SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8);
-    SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
-    SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8);
-    SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
-    SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
     SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
@@ -66,7 +61,18 @@ bool init_sdl_3Demu(void)
 
     ctx = SDL_GL_CreateContext(win);
     if (!ctx)
-        return false;
+	{
+        printf("Failed to create GL context: %s\n", SDL_GetError());
+		return false;
+	}
+	
+	int v[5];
+	SDL_GL_GetAttribute(SDL_GL_RED_SIZE, v);
+    SDL_GL_GetAttribute(SDL_GL_GREEN_SIZE, v+1);
+    SDL_GL_GetAttribute(SDL_GL_BLUE_SIZE, v+2);
+    SDL_GL_GetAttribute(SDL_GL_ALPHA_SIZE, v+3);
+    SDL_GL_GetAttribute(SDL_GL_DEPTH_SIZE, v+4);
+	printf("GL buffer format: R=%d G=%d B=%d A=%d D=%d\n", v[0], v[1], v[2], v[3], v[4]);
 
     printf("OGL/SDL Renderer has finished the initialization.\n");
 


### PR DESCRIPTION
Generally it's not recommended to force visual buffer format but instead let SDL decide which one is better, because not all formats are available on cards without screens.
Let's just add some diagnostics messages after GL context creation.
Fixes #399 