### PR TITLE
Pullreq/commandline2

### DIFF
--- a/desmume/src/commandline.cpp
+++ b/desmume/src/commandline.cpp
@@ -39,11 +39,12 @@ int _commandline_linux_nojoy = 0;
 CommandLine::CommandLine()
 : is_cflash_configured(false)
 , _load_to_memory(-1)
-, _play_movie_file(0)
-, _record_movie_file(0)
-, _cflash_image(0)
-, _cflash_path(0)
-, _gbaslot_rom(0)
+, nds_file("")
+, play_movie_file("")
+, record_movie_file("")
+, cflash_image("")
+, cflash_path("")
+, gbaslot_rom("")
 , _bios_arm9(NULL)
 , _bios_arm7(NULL)
 , _bios_swi(0)
@@ -58,15 +59,15 @@ CommandLine::CommandLine()
 , _gamehacks(-1)
 , _texture_deposterize(-1)
 , _texture_smooth(-1)
-, _slot1(NULL)
-, _slot1_fat_dir(NULL)
+, slot1("")
+, slot1_fat_dir("")
 , _slot1_fat_dir_type(false)
 , _slot1_no8000prot(0)
 #ifdef HAVE_JIT
 , _cpu_mode(-1)
 , _jit_size(-1)
 #endif
-, _console_type(NULL)
+, console_type("")
 , _advanscene_import(NULL)
 , load_slot(-1)
 , arm9_gdb_port(0)
@@ -358,8 +359,8 @@ bool CommandLine::parse(int argc,char **argv)
 
 		//slot-2 contents
 		case OPT_SLOT2_CFLASH_IMAGE: cflash_image = optarg; break;
-		case OPT_SLOT2_CFLASH_DIR: _cflash_path = optarg; break;
-		case OPT_SLOT2_GBAGAME: _gbaslot_rom = optarg; break;
+		case OPT_SLOT2_CFLASH_DIR: cflash_path = optarg; break;
+		case OPT_SLOT2_GBAGAME: gbaslot_rom = optarg; break;
 
 		//commands
 		case OPT_LOAD_SLOT: load_slot = atoi(optarg);  break;
@@ -518,8 +519,9 @@ bool CommandLine::validate()
 		printerror("If either firmware boot is used, firmware path must be specified.\n");
  	}
 
-	if((_cflash_image && _gbaslot_rom) || (_cflash_path && _gbaslot_rom)) {
+	if((cflash_image != "" && gbaslot_rom != "") || (cflash_path != "" && gbaslot_rom != "")) {
 		printerror("Cannot specify both cflash and gbaslot rom (both occupy SLOT-2)\n");
+		return false;
 	}
 
 	if (autodetect_method < -1 || autodetect_method > 1) {

--- a/desmume/src/commandline.h
+++ b/desmume/src/commandline.h
@@ -86,11 +86,6 @@ public:
 	int _spu_sync_mode;
 	int _spu_sync_method;
 private:
-	char* _play_movie_file;
-	char* _record_movie_file;
-	char* _cflash_image;
-	char* _cflash_path;
-	char* _gbaslot_rom;
 	char* _bios_arm9, *_bios_arm7;
 	char* _fw_path;
 	int _fw_boot;
@@ -107,9 +102,6 @@ private:
 	int _cpu_mode;
 	int _jit_size;
 #endif
-	char* _slot1;
-	char *_slot1_fat_dir;
-	char* _console_type;
 	char* _advanscene_import;
 	int _rtc_day;
 	int _rtc_hour;

--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -3549,16 +3549,13 @@ static void Teardown() {
 #endif
 }
 
-static void
-handle_open(GApplication *application,
-            GFile **files,
-            gint n_files,
-            const gchar *hint,
+static gint
+ignore_command_line(GApplication *application,
+            GApplicationCommandLine *command_line,
             gpointer user_data)
 {
-    configured_features *my_config = static_cast<configured_features*>(user_data);
-    my_config->nds_file = g_file_get_path(files[0]);
     common_gtk_main(application, user_data);
+    return 0;
 }
 
 int main (int argc, char *argv[])
@@ -3578,10 +3575,9 @@ int main (int argc, char *argv[])
       fprintf(stderr, "Warning: X11 not thread-safe\n");
     }
 
-  // TODO: pass G_APPLICATION_HANDLES_COMMAND_LINE instead.
-  GtkApplication *app = gtk_application_new("org.desmume.DeSmuME", G_APPLICATION_HANDLES_OPEN);
+  GtkApplication *app = gtk_application_new("org.desmume.DeSmuME", G_APPLICATION_HANDLES_COMMAND_LINE);
   g_signal_connect (app, "activate", G_CALLBACK(common_gtk_main), &my_config);
-  g_signal_connect (app, "open", G_CALLBACK(handle_open), &my_config);
+  g_signal_connect (app, "command-line", G_CALLBACK(ignore_command_line), &my_config);
   g_action_map_add_action_entries(G_ACTION_MAP(app),
                                   app_entries, G_N_ELEMENTS(app_entries),
                                   app);


### PR DESCRIPTION
Linux/GTK: fix command line parsing

Specifying any options on the command line besides the ROM dump aborts with "Unknown option <--option-name>". Also a lot of parsed file names were stored in private members of CommandLine and never exposed to the main application.