### PR TITLE
Add aarch64 string

### DIFF
--- a/desmume/src/version.cpp
+++ b/desmume/src/version.cpp
@@ -50,6 +50,8 @@
 	#define DESMUME_PLATFORM_STRING " ARM"
 #elif defined(__thumb__)
 	#define DESMUME_PLATFORM_STRING " ARM-Thumb"
+#elif defined(__aarch64__)
+	#define DESMUME_PLATFORM_STRING " AArch64"
 #elif defined(__ppc64__)
 	#define DESMUME_PLATFORM_STRING " PPC64"
 #elif defined(__ppc__) || defined(_M_PPC)


### PR DESCRIPTION
Adds aarch64 to the lists of available DESMUME_PLATFORM_STRINGs.
Cherry-picked from 0d763b350a3ce0de7ee4d965ca54c5f3af4373f8.