### PR TITLE
Change background color on Linux

### DIFF
--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -507,6 +507,7 @@ static GtkWidget *pWindow;
 static GtkWidget *pToolBar;
 static GtkWidget *pStatusBar;
 static GtkWidget *pDrawingArea;
+static GtkWidget *pContentBox;
 
 struct nds_screen_t {
     guint gap_size;
@@ -3013,7 +3014,15 @@ common_gtk_main(GApplication *app, gpointer user_data)
     pToolBar = GTK_WIDGET(gtk_builder_get_object(builder, "toolbar"));
     pDrawingArea = GTK_WIDGET(gtk_builder_get_object(builder, "drawing-area"));
     pStatusBar = GTK_WIDGET(gtk_builder_get_object(builder, "status-bar"));
+    pContentBox = GTK_WIDGET(gtk_builder_get_object(builder, "content-box"));
     g_object_unref(builder);
+
+    /* Set colors for content box background and status bar text */
+    GdkRGBA color_black = { 0.0, 0.0, 0.0, 1.0 };
+    gtk_widget_override_background_color(pContentBox, GTK_STATE_FLAG_NORMAL, &color_black);
+
+    GdkRGBA color_soft_gray = { 0.8, 0.8, 0.8, 1.0 };
+    gtk_widget_override_color(pStatusBar, GTK_STATE_FLAG_NORMAL, &color_soft_gray);
 
     gtk_application_add_window(GTK_APPLICATION(app), GTK_WINDOW(pWindow));
 

--- a/desmume/src/frontend/posix/gtk/main.ui
+++ b/desmume/src/frontend/posix/gtk/main.ui
@@ -7,7 +7,7 @@
     <property name="resizable">True</property>
     <property name="show-menubar">True</property>
     <child>
-      <object class="GtkBox">
+      <object class="GtkBox" id="content-box">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="orientation">vertical</property>

--- a/desmume/src/frontend/posix/gtk/main.ui
+++ b/desmume/src/frontend/posix/gtk/main.ui
@@ -7,7 +7,7 @@
     <property name="resizable">True</property>
     <property name="show-menubar">True</property>
     <child>
-      <object class="GtkBox" id="content-box">
+      <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
@@ -79,25 +79,36 @@
           </packing>
         </child>
         <child>
-          <object class="GtkDrawingArea" id="drawing-area">
+          <object class="GtkBox" id="content-box">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkDrawingArea" id="drawing-area">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkStatusbar" id="status-bar">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkStatusbar" id="status-bar">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
           </packing>
         </child>
       </object>


### PR DESCRIPTION
This PR updates #403 for the current desmume-gtk (Linux) code.

Up until now, the Desmume looked like the picture below on my machine (and perhaps Linux machines in general)
![before-update](https://user-images.githubusercontent.com/2720400/133191685-43277952-0bd8-4ae0-9037-8b40acf5015d.png)

The light backgrounds were an eyesore. This commit changes the background color to black and the status bar text to a light gray so that it is readable on the black background.
![after-update](https://user-images.githubusercontent.com/2720400/133191817-450ce7b2-dda2-4cc1-9b3c-fab771d98033.png).

It's obviously not perfect: the toolbar is still light-themed (I hope to fix this at some point by defaulting to a dark GTK theme), and the buttons still become a whiteish color on hover (a theming issue). However the current solution is good enough in fullscreen, where the clashing elements are hidden. I was hoping to get this merged for now
