### PR TITLE
posix: in __glx_initOpenGL, add null check after XOpenDisplay

### DIFF
--- a/desmume/src/frontend/posix/shared/glx_3Demu.cpp
+++ b/desmume/src/frontend/posix/shared/glx_3Demu.cpp
@@ -66,7 +66,7 @@ static bool __glx_initOpenGL(const int requestedProfile, const int requestedVers
 
 	currDisplay = XOpenDisplay(NULL);
 	if (currDisplay == NULL) {
-	puts("GLX: Failed to connect to the X display.");
+	puts("GLX: Failed to connect to the X display. (GLX requires a compatible X Server.");
 		return false;
 	}
 


### PR DESCRIPTION
I found a missing null check which results in a segfault on accident by running a DeSmuME build with GLX enabled in Wayland. By adding this check, this combination now gracefully falls back to the SoftRasterizer.

I wondered if there was also a way to try falling back to the SDL renderer first in such a case, but ultimately decided that linking against the extra header was not worth it for how niche I believe this scenario to be.