### PR TITLE
Add backup memory import/export functions to interface API

### DIFF
--- a/desmume/src/frontend/interface/interface.cpp
+++ b/desmume/src/frontend/interface/interface.cpp
@@ -287,21 +287,7 @@ EXPORTED char* desmume_savestate_slot_date(int index)
     return savestates[index].date;
 }
 
-EXPORTED BOOL desmume_backup_import_file(const char *filename) {
-	if (!nds.backupDevice.isBackupDeviceAvailable()) {
-		return FALSE;
-	}
-	
-	bool success = nds.backupDevice.importData(filename, 0);
-	
-	if (success) {
-		NDS_Reset();
-	}
-	
-	return success ? TRUE : FALSE;
-}
-
-EXPORTED BOOL desmume_backup_import_raw(const char *filename, unsigned int force_size) {
+EXPORTED BOOL desmume_backup_import_file(const char *filename, unsigned int force_size) {
 	if (!nds.backupDevice.isBackupDeviceAvailable()) {
 		return FALSE;
 	}

--- a/desmume/src/frontend/interface/interface.h
+++ b/desmume/src/frontend/interface/interface.h
@@ -109,24 +109,15 @@ EXPORTED char* desmume_savestate_slot_date(int index);
 // Battery save (backup memory) import/export
 
 /**
- * Import battery save file with automatic format detection.
+ * Import battery save file with optional size override.
  * Supports .sav (raw), .dsv (DeSmuME), .duc (Action Replay), .dss (DSOrganize).
  * The emulator will automatically reset after successful import.
- * 
- * @param filename Path to battery save file
- * @return TRUE on success, FALSE on failure
- */
-EXPORTED BOOL desmume_backup_import_file(const char *filename);
-
-/**
- * Import battery save file with manual size override.
- * Use this when auto-detection fails or you need to force a specific backup size.
  * 
  * @param filename Path to battery save file
  * @param force_size Backup size in bytes (0 = auto-detect, or explicit size like 524288 for 512KB)
  * @return TRUE on success, FALSE on failure
  */
-EXPORTED BOOL desmume_backup_import_raw(const char *filename, unsigned int force_size);
+EXPORTED BOOL desmume_backup_import_file(const char *filename, unsigned int force_size);
 
 /**
  * Export current battery save to .dsv file.


### PR DESCRIPTION
## Problem
The interface API has `desmume_savestate_load/save` for savestates but nothing equivalent for battery saves (.sav/.dsv files). This means tools using the library can't load in-game saves programmatically - they have to use the GUI first.

## Solution
Added three functions to interface.h/cpp that wrap the existing BackupDevice methods:

```cpp
/**
 * Import battery save file with optional size override.
 * Supports .sav (raw), .dsv (DeSmuME), .duc (Action Replay), .dss (DSOrganize).
 * The emulator will automatically reset after successful import.
 * 
 * @param filename Path to battery save file
 * @param force_size Backup size in bytes (0 = auto-detect, or explicit size like 524288 for 512KB)
 * @return TRUE on success, FALSE on failure
 */
EXPORTED BOOL desmume_backup_import_file(const char *filename, unsigned int force_size);

/**
 * Export current battery save to .dsv file.
 * 
 * @param filename Destination path for .dsv file
 * @return TRUE on success, FALSE on failure
 */
EXPORTED BOOL desmume_backup_export_file(const char *filename);
```
The implementation is straightforward - it calls BackupDevice::importData() (which already handles .sav, .dsv, .duc formats) and resets the emulator on success, same as the GUI does.

## Testing
Compiles cleanly on Windows (VS2022 x64)
Will do functional testing through py-desmume bindings once this merges

---

The functions follow the same pattern as the existing savestate API, just for backup memory instead. Let me know if you want any changes to the implementation.