### PR TITLE
Add backup memory import/export API to interface

### DIFF
--- a/desmume/src/frontend/interface/interface.cpp
+++ b/desmume/src/frontend/interface/interface.cpp
@@ -287,6 +287,22 @@ EXPORTED char* desmume_savestate_slot_date(int index)
     return savestates[index].date;
 }
 
+EXPORTED BOOL desmume_backup_import_file(const char *filename, unsigned int force_size) {
+	const auto success = MMU_new.backupDevice.importData(filename, force_size);
+
+	if (!success) {
+        return FALSE;
+	}
+    
+    NDS_Reset();
+	
+    return TRUE;
+}
+
+EXPORTED BOOL desmume_backup_export_file(const char *filename) {
+	return MMU_new.backupDevice.exportData(filename) ? TRUE : FALSE;
+}
+
 EXPORTED BOOL desmume_gpu_get_layer_main_enable_state(int layer_index)
 {
     return GPU->GetEngineMain()->GetLayerEnableState(layer_index);

--- a/desmume/src/frontend/interface/interface.h
+++ b/desmume/src/frontend/interface/interface.h
@@ -106,6 +106,49 @@ EXPORTED void desmume_savestate_slot_save(int index);
 EXPORTED BOOL desmume_savestate_slot_exists(int index);
 EXPORTED char* desmume_savestate_slot_date(int index);
 
+// Battery save (backup memory) import/export
+
+/**
+ * Import battery save file with optional size override.
+ * Supports .sav (raw), .dsv (DeSmuME), .duc (Action Replay), .dss (DSOrganize).
+ * The emulator will automatically reset after successful import.
+ *
+ * Prerequisites:
+ *   - MMU_new.backupDevice is a global object initialized at program startup
+ *   - A ROM should be loaded via desmume_open() first - the BackupDevice constructor
+ *     checks gameInfo.romsize and returns early if no ROM is loaded, preventing
+ *     proper initialization of the save file path
+ *
+ * Typical usage:
+ *   desmume_init();              // Initialize emulator
+ *   desmume_open("game.nds");    // Load ROM (initializes backup device filename)
+ *   desmume_backup_import_file("save.sav", 0);  // Now safe to import
+ *
+ * @param filename Path to battery save file
+ * @param force_size Backup size in bytes (0 = auto-detect, or explicit size like 524288 for 512KB)
+ * @return TRUE on success, FALSE on failure
+ */
+EXPORTED BOOL desmume_backup_import_file(const char *filename, unsigned int force_size);
+
+/**
+ * Export current battery save to .dsv file.
+ *
+ * Prerequisites:
+ *   - MMU_new.backupDevice is a global object initialized at program startup
+ *   - A ROM must be loaded via desmume_open() first - the BackupDevice needs
+ *     the ROM to be loaded to have a valid save filename and data
+ *
+ * Typical usage:
+ *   desmume_init();              // Initialize emulator
+ *   desmume_open("game.nds");    // Load ROM
+ *   // ... play game, save data is created ...
+ *   desmume_backup_export_file("backup.dsv");  // Export save data
+ *
+ * @param filename Destination path for .dsv file
+ * @return TRUE on success, FALSE on failure
+ */
+EXPORTED BOOL desmume_backup_export_file(const char *filename);
+
 EXPORTED BOOL desmume_gpu_get_layer_main_enable_state(int layer_index);
 EXPORTED BOOL desmume_gpu_get_layer_sub_enable_state(int layer_index);
 EXPORTED void desmume_gpu_set_layer_main_enable_state(int layer_index, BOOL the_state);


### PR DESCRIPTION
## Problem
The interface API has `desmume_savestate_load/save` for savestates but nothing equivalent for battery saves (.sav/.dsv files). This means tools using the library can't load in-game saves programmatically - they have to use the GUI first.

## Solution
Added three functions to interface.h/cpp that wrap the existing BackupDevice methods:

```cpp
/**
 * Import battery save file with optional size override.
 * Supports .sav (raw), .dsv (DeSmuME), .duc (Action Replay), .dss (DSOrganize).
 * The emulator will automatically reset after successful import.
 *
 * Prerequisites:
 *   - MMU_new.backupDevice is a global object initialized at program startup
 *   - A ROM should be loaded via desmume_open() first - the BackupDevice constructor
 *     checks gameInfo.romsize and returns early if no ROM is loaded, preventing
 *     proper initialization of the save file path
 *
 * Typical usage:
 *   desmume_init();              // Initialize emulator
 *   desmume_open("game.nds");    // Load ROM (initializes backup device filename)
 *   desmume_backup_import_file("save.sav", 0);  // Now safe to import
 *
 * @param filename Path to battery save file
 * @param force_size Backup size in bytes (0 = auto-detect, or explicit size like 524288 for 512KB)
 * @return TRUE on success, FALSE on failure
 */
EXPORTED BOOL desmume_backup_import_file(const char *filename, unsigned int force_size);

/**
 * Export current battery save to .dsv file.
 *
 * Prerequisites:
 *   - MMU_new.backupDevice is a global object initialized at program startup
 *   - A ROM must be loaded via desmume_open() first - the BackupDevice needs
 *     the ROM to be loaded to have a valid save filename and data
 *
 * Typical usage:
 *   desmume_init();              // Initialize emulator
 *   desmume_open("game.nds");    // Load ROM
 *   // ... play game, save data is created ...
 *   desmume_backup_export_file("backup.dsv");  // Export save data
 *
 * @param filename Destination path for .dsv file
 * @return TRUE on success, FALSE on failure
 */
EXPORTED BOOL desmume_backup_export_file(const char *filename);
```
The implementation is straightforward - it calls BackupDevice::importData() (which already handles .sav, .dsv, .duc formats) and resets the emulator on success, same as the GUI does.

## Testing
Passed all checks on my fork.
Will do functional testing through py-desmume bindings once this merges

---

The functions follow the same pattern as the existing savestate API, just for backup memory instead. Let me know if you want any changes to the implementation.