### PR TITLE
fix: security, memory safety, correctness, and CI improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
       - name: buildit
         run: |
           cd desmume/src/frontend/windows/
-          echo "OPT=-fstrength-reduce -fthread-jumps -fcse-follow-jumps -fcse-skip-blocks -frerun-cse-after-loop -fexpensive-optimizations -fforce-addr -fomit-frame-pointer -ffast-math -march=pentium4 -mtune=pentium4 -mmmx -msse2" > config.mak
+          echo "OPT=-fthread-jumps -fcse-follow-jumps -fcse-skip-blocks -frerun-cse-after-loop -fexpensive-optimizations -fomit-frame-pointer -ffast-math -march=x86-64 -mtune=generic -msse2" > config.mak
           make -j8
           mkdir /tmp/DeSmuME
           cp desmume.exe /tmp/DeSmuME
@@ -84,27 +84,58 @@ jobs:
           name: desmume-mingw-win32
           path: /tmp/DeSmuME.tar.xz
 
-  build_macos:
-    name: Build DeSmuME (macOS)
+  build_macos_intel:
+    name: Build DeSmuME (macOS/Intel64)
     runs-on: macos-14
 
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      
+
+      - name: install xcpretty
+        run: gem install xcpretty
+
       - name: xcodebuild
         run: |
           cd desmume/src/frontend/cocoa/
           xcodebuild archive -project "DeSmuME (Latest).xcodeproj" -scheme "DeSmuME (macOS App; Intel64 -- Latest Xcode)" -arch x86_64 -archivePath "$(pwd)/desmume.xcarchive" | xcpretty -c
-      
+
       - name: make zip
         run: |
           cd desmume/src/frontend/cocoa/desmume.xcarchive/Products/Applications/
           7z a DeSmuME.app.zip DeSmuME.app
 
-      - name: Upload artifict
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: macos
+          name: macos-intel64
           path: desmume/src/frontend/cocoa/desmume.xcarchive/Products/Applications/DeSmuME.app.zip
-          if-no-files-found: error 
+          if-no-files-found: error
+
+  build_macos_arm64:
+    name: Build DeSmuME (macOS/AppleSilicon)
+    runs-on: macos-14
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: install xcpretty
+        run: gem install xcpretty
+
+      - name: xcodebuild
+        run: |
+          cd desmume/src/frontend/cocoa/
+          xcodebuild archive -project "DeSmuME (Latest).xcodeproj" -scheme "DeSmuME (macOS App; AppleSilicon -- Latest Xcode)" -arch arm64 -archivePath "$(pwd)/desmume-arm64.xcarchive" | xcpretty -c
+
+      - name: make zip
+        run: |
+          cd desmume/src/frontend/cocoa/desmume-arm64.xcarchive/Products/Applications/
+          7z a DeSmuME.app.zip DeSmuME.app
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-arm64
+          path: desmume/src/frontend/cocoa/desmume-arm64.xcarchive/Products/Applications/DeSmuME.app.zip
+          if-no-files-found: error

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/desmume/src/MMU.h
+++ b/desmume/src/MMU.h
@@ -722,12 +722,15 @@ FORCEINLINE u8 _MMU_read08(const int PROCNUM, const MMU_ACCESS_TYPE AT, const u3
 #endif
 
 	// break points, wheee
-	for (size_t i = 0; i < memReadBreakPoints.size(); ++i)
+	if (!memReadBreakPoints.empty())
 	{
-		if (addr == memReadBreakPoints[i])
+		for (size_t i = 0; i < memReadBreakPoints.size(); ++i)
 		{
-			execute = false;
-			i = memReadBreakPoints.size();
+			if (addr == memReadBreakPoints[i])
+			{
+				execute = false;
+				break;
+			}
 		}
 	}
 
@@ -770,12 +773,15 @@ FORCEINLINE u16 _MMU_read16(const int PROCNUM, const MMU_ACCESS_TYPE AT, const u
 #endif
 
 	// break points, wheee
-	for (size_t i = 0; i < memReadBreakPoints.size(); ++i)
+	if (!memReadBreakPoints.empty())
 	{
-		if (addr == memReadBreakPoints[i])
+		for (size_t i = 0; i < memReadBreakPoints.size(); ++i)
 		{
-			execute = false;
-			i = memReadBreakPoints.size();
+			if (addr == memReadBreakPoints[i])
+			{
+				execute = false;
+				break;
+			}
 		}
 	}
 
@@ -830,12 +836,15 @@ FORCEINLINE u32 _MMU_read32(const int PROCNUM, const MMU_ACCESS_TYPE AT, const u
     call_registered_interface_mem_hook(addr, 4, HOOK_READ);
 #endif
 	// break points, wheee
-	for (size_t i = 0; i < memReadBreakPoints.size(); ++i)
+	if (!memReadBreakPoints.empty())
 	{
-		if (addr == memReadBreakPoints[i])
+		for (size_t i = 0; i < memReadBreakPoints.size(); ++i)
 		{
-			execute = false;
-			i = memReadBreakPoints.size();
+			if (addr == memReadBreakPoints[i])
+			{
+				execute = false;
+				break;
+			}
 		}
 	}
 
@@ -895,12 +904,15 @@ FORCEINLINE void _MMU_write08(const int PROCNUM, const MMU_ACCESS_TYPE AT, const
 	}
 
 	// break points, wheee
-	for (size_t i = 0; i < memWriteBreakPoints.size(); ++i)
+	if (!memWriteBreakPoints.empty())
 	{
-		if (addr == memWriteBreakPoints[i])
+		for (size_t i = 0; i < memWriteBreakPoints.size(); ++i)
 		{
-			execute = false;
-			i = memWriteBreakPoints.size();
+			if (addr == memWriteBreakPoints[i])
+			{
+				execute = false;
+				break;
+			}
 		}
 	}
 
@@ -953,12 +965,15 @@ FORCEINLINE void _MMU_write16(const int PROCNUM, const MMU_ACCESS_TYPE AT, const
 	}
 
 	// break points, wheee
-	for (size_t i = 0; i < memWriteBreakPoints.size(); ++i)
+	if (!memWriteBreakPoints.empty())
 	{
-		if (addr == memWriteBreakPoints[i])
+		for (size_t i = 0; i < memWriteBreakPoints.size(); ++i)
 		{
-			execute = false;
-			i = memWriteBreakPoints.size();
+			if (addr == memWriteBreakPoints[i])
+			{
+				execute = false;
+				break;
+			}
 		}
 	}
 
@@ -1008,12 +1023,15 @@ FORCEINLINE void _MMU_write32(const int PROCNUM, const MMU_ACCESS_TYPE AT, const
 	}
 
 	// break points, wheee
-	for (size_t i = 0; i < memWriteBreakPoints.size(); ++i)
+	if (!memWriteBreakPoints.empty())
 	{
-		if (addr == memWriteBreakPoints[i])
+		for (size_t i = 0; i < memWriteBreakPoints.size(); ++i)
 		{
-			execute = false;
-			i = memWriteBreakPoints.size();
+			if (addr == memWriteBreakPoints[i])
+			{
+				execute = false;
+				break;
+			}
 		}
 	}
 

--- a/desmume/src/NDSSystem.h
+++ b/desmume/src/NDSSystem.h
@@ -489,6 +489,7 @@ enum MicMode
 
 struct GameHackCheat
 {
+	virtual ~GameHackCheat() = default;
 	virtual void Run() {}
 
 	void write08(u32 address, u8 value);

--- a/desmume/src/OGLRender.cpp
+++ b/desmume/src/OGLRender.cpp
@@ -832,19 +832,24 @@ Render3DError ShaderProgramCreateOGL(GLuint &vtxShaderID,
 		glCompileShader(vtxShaderID);
 		if (!ValidateShaderCompileOGL(GL_VERTEX_SHADER, vtxShaderID))
 		{
-			error = OGLERROR_SHADER_CREATE_ERROR;
-			return error;
+			glDeleteShader(vtxShaderID);
+			vtxShaderID = 0;
+			return OGLERROR_SHADER_CREATE_ERROR;
 		}
 	}
-	
+
 	if (fragShaderID == 0)
 	{
 		fragShaderID = glCreateShader(GL_FRAGMENT_SHADER);
 		if (fragShaderID == 0)
 		{
 			INFO("OpenGL: Failed to create the fragment shader.\n");
-			error = OGLERROR_SHADER_CREATE_ERROR;
-			return error;
+			if (vtxShaderID != 0)
+			{
+				glDeleteShader(vtxShaderID);
+				vtxShaderID = 0;
+			}
+			return OGLERROR_SHADER_CREATE_ERROR;
 		}
 		
 		const char *fragShaderCStringPtr = fragShaderCString;
@@ -852,6 +857,13 @@ Render3DError ShaderProgramCreateOGL(GLuint &vtxShaderID,
 		glCompileShader(fragShaderID);
 		if (!ValidateShaderCompileOGL(GL_FRAGMENT_SHADER, fragShaderID))
 		{
+			glDeleteShader(fragShaderID);
+			fragShaderID = 0;
+			if (vtxShaderID != 0)
+			{
+				glDeleteShader(vtxShaderID);
+				vtxShaderID = 0;
+			}
 			error = OGLERROR_SHADER_CREATE_ERROR;
 			return error;
 		}

--- a/desmume/src/ROMReader.cpp
+++ b/desmume/src/ROMReader.cpp
@@ -243,7 +243,7 @@ void * ZIPROMReaderInit(const char * filename)
 
 		memset(tmp2,0,sizeof(tmp2));
 		tmp1 = strndup(filename, strlen(filename) - 4);
-		sprintf(tmp2, "%s/%s", tmp1, dirent->d_name);
+		snprintf(tmp2, sizeof(tmp2), "%s/%s", tmp1, dirent->d_name);
 		free(tmp1);
 		return zzip_fopen(tmp2, "rb");
 	}

--- a/desmume/src/SPU.cpp
+++ b/desmume/src/SPU.cpp
@@ -58,10 +58,10 @@ static inline s8 read_s8(u32 addr) { return (s8)_MMU_read08<ARMCPU_ARM7,MMU_AT_D
 
 #define SPUCHAN_PCM16B_AT(x) ((u32)(x) % SPUINTERPOLATION_TAPS)
 
-//#ifdef FASTBUILD
+#ifdef FASTBUILD
 	#undef FORCEINLINE
 	#define FORCEINLINE
-//#endif
+#endif
 
 //static ISynchronizingAudioBuffer* _currentSynchronizer = metaspu_construct(ESynchMethod_Z);
 static ISynchronizingAudioBuffer* _currentSynchronizer = metaspu_construct(ESynchMethod_N);
@@ -223,6 +223,7 @@ int SPU_Init(int coreid, int newBufferSizeBytes)
 	for (size_t i = 0; i < COSINE_INTERPOLATION_RESOLUTION; i++)
 		cos_lut[i] = (u16)floor((1u<<16) * ((1.0 - cos(((double)i/(double)COSINE_INTERPOLATION_RESOLUTION) * M_PI)) * 0.5));
 
+	delete SPU_core;
 	SPU_core = new SPU_struct((int)ceil(samples_per_hline));
 	SPU_Reset();
 

--- a/desmume/src/commandline.cpp
+++ b/desmume/src/commandline.cpp
@@ -457,10 +457,10 @@ bool CommandLine::parse(int argc,char **argv)
 		CommonSettings.autodetectBackupMethod = autodetect_method;
 
 	//TODO NOT MAX PRIORITY! change ARM9BIOS etc to be a std::string
-	if(_bios_arm9) { CommonSettings.UseExtBIOS = true; strcpy(CommonSettings.ARM9BIOS,_bios_arm9); }
-	if(_bios_arm7) { CommonSettings.UseExtBIOS = true; strcpy(CommonSettings.ARM7BIOS,_bios_arm7); }
-	#ifndef HOST_WINDOWS 
-		if(_fw_path) { CommonSettings.UseExtFirmware = true; CommonSettings.UseExtFirmwareSettings = true; strcpy(CommonSettings.ExtFirmwarePath,_fw_path); }
+	if(_bios_arm9) { CommonSettings.UseExtBIOS = true; strncpy(CommonSettings.ARM9BIOS,_bios_arm9,sizeof(CommonSettings.ARM9BIOS)-1); CommonSettings.ARM9BIOS[sizeof(CommonSettings.ARM9BIOS)-1]='\0'; }
+	if(_bios_arm7) { CommonSettings.UseExtBIOS = true; strncpy(CommonSettings.ARM7BIOS,_bios_arm7,sizeof(CommonSettings.ARM7BIOS)-1); CommonSettings.ARM7BIOS[sizeof(CommonSettings.ARM7BIOS)-1]='\0'; }
+	#ifndef HOST_WINDOWS
+		if(_fw_path) { CommonSettings.UseExtFirmware = true; CommonSettings.UseExtFirmwareSettings = true; strncpy(CommonSettings.ExtFirmwarePath,_fw_path,sizeof(CommonSettings.ExtFirmwarePath)-1); CommonSettings.ExtFirmwarePath[sizeof(CommonSettings.ExtFirmwarePath)-1]='\0'; }
 	#endif
 	if(_fw_boot) CommonSettings.BootFromFirmware = true;
 	if(_bios_swi) CommonSettings.SWIFromBIOS = true;

--- a/desmume/src/firmware.cpp
+++ b/desmume/src/firmware.cpp
@@ -136,10 +136,24 @@ u32 CFIRMWARE::_decrypt(const u8 *in, u8* &out)
 
 				len = (data >> 12) + 3;
 				offset = (data & 0xFFF);
+
+				// Prevent unsigned underflow: ensure back-reference is within output
+				if (offset >= xOut)
+				{
+					delete[] out;
+					out = NULL;
+					return 0;
+				}
 				windowOffset = (xOut - offset - 1);
 
 				for(j = 0; j < len; j++)
 				{
+					if (xOut >= blockSize || windowOffset >= blockSize)
+					{
+						delete[] out;
+						out = NULL;
+						return 0;
+					}
 					T1WriteByte(out, xOut, T1ReadByte(out, windowOffset));
 					xOut++;
 					windowOffset++;
@@ -150,6 +164,12 @@ u32 CFIRMWARE::_decrypt(const u8 *in, u8* &out)
 			}
 			else
 			{
+				if (xOut >= blockSize)
+				{
+					delete[] out;
+					out = NULL;
+					return 0;
+				}
 				T1WriteByte(out, xOut, T1ReadByte((u8*)curBlock, (xIn % 8)));
 				xOut++;
 				xIn++;
@@ -166,7 +186,7 @@ u32 CFIRMWARE::_decrypt(const u8 *in, u8* &out)
 			d = ((d << 1) & 0xFF);
 		}
 	}
-	
+
 	return (blockSize);
 }
 
@@ -222,10 +242,24 @@ u32 CFIRMWARE::_decompress(const u8 *in, u8* &out)
 
 				len = (data >> 12) + 3;
 				offset = (data & 0xFFF);
+
+				// Prevent unsigned underflow: ensure back-reference is within output
+				if (offset >= xOut)
+				{
+					delete[] out;
+					out = NULL;
+					return 0;
+				}
 				windowOffset = (xOut - offset - 1);
 
 				for(j = 0; j < len; j++)
 				{
+					if (xOut >= blockSize || windowOffset >= blockSize)
+					{
+						delete[] out;
+						out = NULL;
+						return 0;
+					}
 					T1WriteByte(out, xOut, T1ReadByte(out, windowOffset));
 					xOut++;
 					windowOffset++;
@@ -236,6 +270,12 @@ u32 CFIRMWARE::_decompress(const u8 *in, u8* &out)
 			}
 			else
 			{
+				if (xOut >= blockSize)
+				{
+					delete[] out;
+					out = NULL;
+					return 0;
+				}
 				T1WriteByte(out, xOut, T1ReadByte((u8*)curBlock, (xIn % 8)));
 				xOut++;
 				xIn++;
@@ -251,7 +291,7 @@ u32 CFIRMWARE::_decompress(const u8 *in, u8* &out)
 			d = ((d << 1) & 0xFF);
 		}
 	}
-	
+
 	return (blockSize);
 }
 //================================================================================

--- a/desmume/src/frontend/interface/interface.cpp
+++ b/desmume/src/frontend/interface/interface.cpp
@@ -293,9 +293,8 @@ EXPORTED BOOL desmume_backup_import_file(const char *filename, unsigned int forc
 	if (!success) {
         return FALSE;
 	}
-    
-    NDS_Reset();
-	
+
+	// NDS_Reset() is already called inside importData() on success
     return TRUE;
 }
 

--- a/desmume/src/frontend/interface/interface.h
+++ b/desmume/src/frontend/interface/interface.h
@@ -131,7 +131,12 @@ EXPORTED char* desmume_savestate_slot_date(int index);
 EXPORTED BOOL desmume_backup_import_file(const char *filename, unsigned int force_size);
 
 /**
- * Export current battery save to .dsv file.
+ * Export current battery save to file.
+ *
+ * Supported formats (determined by file extension):
+ *   - .dsv  - DeSmuME native save format (raw data + metadata footer)
+ *   - .sav  - Raw save data (no metadata)
+ *   - .sav* - no$GBA format
  *
  * Prerequisites:
  *   - MMU_new.backupDevice is a global object initialized at program startup
@@ -144,7 +149,7 @@ EXPORTED BOOL desmume_backup_import_file(const char *filename, unsigned int forc
  *   // ... play game, save data is created ...
  *   desmume_backup_export_file("backup.dsv");  // Export save data
  *
- * @param filename Destination path for .dsv file
+ * @param filename Destination path (.dsv, .sav, or .sav*)
  * @return TRUE on success, FALSE on failure
  */
 EXPORTED BOOL desmume_backup_export_file(const char *filename);

--- a/desmume/src/frontend/posix/gtk2/main.cpp
+++ b/desmume/src/frontend/posix/gtk2/main.cpp
@@ -1251,7 +1251,7 @@ static void ImportExportBackupDialog(bool is_export)
             gtk_dialog_run(GTK_DIALOG(pDialog));
             gtk_widget_destroy(pDialog);
         } else if (!is_export) {
-            NDS_Reset(); // reboot game
+            // NDS_Reset() is already called inside importData() on success
         }
         g_free(sPath);
         break;

--- a/desmume/src/frontend/windows/importSave.cpp
+++ b/desmume/src/frontend/windows/importSave.cpp
@@ -197,7 +197,7 @@ bool importSave(HWND hwnd, HINSTANCE hAppInst)
 		if (res)
 		{
 			printf("Save was successfully imported\n");
-			NDS_Reset(); // reboot game
+			// NDS_Reset() is already called inside importData() on success
 		}
 		else
 			printf("Save was not successfully imported");

--- a/desmume/src/gdbstub/gdbstub.cpp
+++ b/desmume/src/gdbstub/gdbstub.cpp
@@ -800,6 +800,9 @@ processPacket_gdb( SOCKET_TYPE sock, const uint8_t *packet,
     if ( hexToInt( &rx_ptr, &addr)) {
       if ( *rx_ptr++ == ',') {
         if ( hexToInt( &rx_ptr, &length)) {
+          // Cap length to prevent buffer overflow: mem2hex writes length*2 bytes
+          if (length > (BUFMAX / 2) - 32)
+            length = (BUFMAX / 2) - 32;
           //DEBUG_LOG("mem read from %08x (%d)\n", addr, length);
           if ( !mem2hex( stub->direct_memio, addr, out_ptr, length)) {
             strcpy ( (char *)out_ptr, "E03");
@@ -1602,6 +1605,10 @@ createStub_gdb( uint16_t port,
 
     if ( stub->thread == NULL) {
       LOG_ERROR("Failed to create listener thread\n");
+      if (stub->listen_fd != -1)
+        CLOSESOCKET(stub->listen_fd);
+      delete stub->direct_memio;
+      delete stub->gdb_memio;
       delete stub;
       stub = NULL;
     }
@@ -1610,6 +1617,10 @@ createStub_gdb( uint16_t port,
     }
   }
   else {
+    if (stub->listen_fd != -1)
+      CLOSESOCKET(stub->listen_fd);
+    delete stub->direct_memio;
+    delete stub->gdb_memio;
     delete stub;
     stub = NULL;
   }

--- a/desmume/src/gdbstub/gdbstub.cpp
+++ b/desmume/src/gdbstub/gdbstub.cpp
@@ -1114,7 +1114,12 @@ createSocket ( int port) {
 
   if ( sock != INVALID_SOCKET)
   {
-#ifndef WIN32
+#ifdef WIN32
+      /* On Windows, use SO_EXCLUSIVEADDRUSE for safe port reuse.
+         SO_REUSEADDR on Windows allows multiple sockets on the same port (security risk). */
+      int exclusive = 1;
+      setsockopt(sock, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, (const char*)&exclusive, sizeof(int));
+#else
       /* reuse socket, might have stall state if previously used */
       int yes = 1;
       setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int));

--- a/desmume/src/gdbstub/gdbstub.cpp
+++ b/desmume/src/gdbstub/gdbstub.cpp
@@ -57,17 +57,20 @@ slock *cpu_mutex = NULL;
 #define UNUSED_PARM( parm) parm
 #endif
 
+static int gdbstub_debug_enabled = -1;
+static inline int gdbstub_debug_check() {
+	if (gdbstub_debug_enabled < 0)
+		gdbstub_debug_enabled = (getenv("GDBSTUB_DEBUG") != NULL) ? 1 : 0;
+	return gdbstub_debug_enabled;
+}
+
 #if 1
-#define DEBUG_LOG( fmt, ...) if(getenv("GDBSTUB_DEBUG")) fprintf(stdout, fmt, ##__VA_ARGS__)
+#define DEBUG_LOG( fmt, ...) if(gdbstub_debug_check()) fprintf(stdout, fmt, ##__VA_ARGS__)
 #else
 #define DEBUG_LOG( fmt, ...)
 #endif
 
-#if 0
 #define LOG_ERROR( fmt, ...) fprintf(stderr, fmt, ##__VA_ARGS__)
-#else
-#define LOG_ERROR( fmt, ...)
-#endif
 
 #ifdef WIN32
 #define RECV(A,B,C) recv(A, (char*)B, C, 0)

--- a/desmume/src/mc.cpp
+++ b/desmume/src/mc.cpp
@@ -1109,10 +1109,13 @@ bool BackupDevice::exportData(const char *filename)
 	{
 		char tmp[MAX_PATH];
 		memset(tmp, 0, MAX_PATH);
-		strcpy(tmp, filename);
+		strncpy(tmp, filename, MAX_PATH - 1);
 		tmp[strlen(tmp)-1] = 0;
 		return export_no_gba(tmp);
 	}
+
+	if (memcmp(filename + strlen(filename) - 4, ".dsv", 4) == 0)
+		return export_dsv(filename);
 
 	if (memcmp(filename + strlen(filename) - 4, ".sav", 4) == 0)
 		return export_raw(filename);
@@ -1408,6 +1411,45 @@ bool BackupDevice::export_raw(const char* filename)
 	return true;
 }
 
+bool BackupDevice::export_dsv(const char* filename)
+{
+	// Export in native DeSmuME .dsv format (raw data + padding + footer)
+	std::vector<u8> data(this->_fsize);
+	u32 pos = this->_fpMC->ftell();
+	this->_fpMC->fseek(0, SEEK_SET);
+	this->_fpMC->fread((char *)&data[0], this->_fsize);
+	this->_fpMC->fseek(pos, SEEK_SET);
+
+	FILE *outf = fopen(filename, "wb");
+	if (!outf) return false;
+
+	u32 size = (u32)data.size();
+	u32 padSize = pad_up_size(size);
+
+	// Write raw data
+	if (size > 0)
+		fwrite(&data[0], 1, size, outf);
+
+	// Pad to standard save size
+	for (u32 i = size; i < padSize; i++)
+		fputc(uninitializedValue, outf);
+
+	// Write DSV footer (matches the format written by ensure())
+	fprintf(outf, "%s", DESMUME_BACKUP_FOOTER_TXT);
+
+	u32 leVal;
+	leVal = LOCAL_TO_LE_32(size);       fwrite(&leVal, 4, 1, outf);
+	leVal = LOCAL_TO_LE_32(padSize);    fwrite(&leVal, 4, 1, outf);
+	leVal = LOCAL_TO_LE_32(this->_info.type);     fwrite(&leVal, 4, 1, outf);
+	leVal = LOCAL_TO_LE_32(this->_addr_size);     fwrite(&leVal, 4, 1, outf);
+	leVal = LOCAL_TO_LE_32(this->_info.size);     fwrite(&leVal, 4, 1, outf);
+	leVal = LOCAL_TO_LE_32((u32)0);     fwrite(&leVal, 4, 1, outf);  // version
+	fprintf(outf, "%s", kDesmumeSaveCookie);
+
+	fclose(outf);
+	return true;
+}
+
 u32 BackupDevice::pad_up_size(u32 startSize)
 {
 	u32 size = startSize;
@@ -1619,8 +1661,21 @@ bool BackupDevice::import_dsv(const char *filename)
 	}
 	
 	// Read the backup data into memory.
+	// Sanity check: DS save data should never exceed 1 MB
+	if (importFileFooter.info.padSize == 0 || importFileFooter.info.padSize > 1024 * 1024)
+	{
+		fclose(theFile);
+		printf("BackupDevice: DSV import failed! Invalid padSize: %u\n", (unsigned int)importFileFooter.info.padSize);
+		return result;
+	}
 	u8 *backupData = (u8 *)malloc(importFileFooter.info.padSize);
-	
+	if (backupData == NULL)
+	{
+		fclose(theFile);
+		printf("BackupDevice: DSV import failed! Could not allocate %u bytes.\n", (unsigned int)importFileFooter.info.padSize);
+		return result;
+	}
+
 	fseek(theFile, 0, SEEK_SET);
 	const size_t backupDataReadByteCount = fread(backupData, 1, importFileFooter.info.padSize, theFile);
 	fclose(theFile); // At this point, both backup data and footer should have been read, so we can close the import file now.

--- a/desmume/src/mc.h
+++ b/desmume/src/mc.h
@@ -151,6 +151,7 @@ public:
 	bool import_dsv(const char *filename);
 	bool export_no_gba(const char* fname);
 	bool export_raw(const char* filename);
+	bool export_dsv(const char* filename);
 	bool no_gba_unpack(u8 *&buf, u32 &size);
 	
 	bool load_movie(EMUFILE *is);

--- a/desmume/src/types.h
+++ b/desmume/src/types.h
@@ -28,9 +28,9 @@
 #endif
 
 //analyze microsoft compilers
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__MINGW64__)
 	#define HOST_WINDOWS
-#endif //_MSC_VER
+#endif
 
 // Determine CPU architecture for platforms that don't use the autoconf script
 #if defined(HOST_WINDOWS) || defined(DESMUME_COCOA)

--- a/desmume/src/wifi.cpp
+++ b/desmume/src/wifi.cpp
@@ -3368,12 +3368,13 @@ bool AdhocCommInterface::Start(WifiHandler* currentWifiHandler)
 	#endif
 
 	// Bind the socket to any address on port 7000.
-	sockaddr_t saddr;
-	saddr.sa_family = AF_INET;
-	*(u32*)&saddr.sa_data[2] = htonl(INADDR_ANY);
-	*(u16*)&saddr.sa_data[0] = htons(BASEPORT);
+	struct sockaddr_in saddr_in;
+	memset(&saddr_in, 0, sizeof(saddr_in));
+	saddr_in.sin_family = AF_INET;
+	saddr_in.sin_addr.s_addr = htonl(INADDR_ANY);
+	saddr_in.sin_port = htons(BASEPORT);
 
-	result = bind(thisSocket, &saddr, sizeof(sockaddr_t));
+	result = bind(thisSocket, (sockaddr_t*)&saddr_in, sizeof(saddr_in));
 	if(result < 0)
 	{
 		closesocket(thisSocket);
@@ -3616,14 +3617,21 @@ bool SoftAPCommInterface::_IsDNSRequestToWFC(u16 ethertype, const u8* body)
 	{
 		// Assemble the requested domain name
 		u8 bitlength = 0; char domainname[256] = "";
+		size_t domainlen = 0;
 		while((bitlength = body[curoffset++]) != 0)
 		{
+			// Bounds check: ensure we don't overflow domainname
+			if (domainlen + bitlength + 1 >= sizeof(domainname))
+				break;
+
 			strncat(domainname, (const char*)&body[curoffset], bitlength);
+			domainlen += bitlength;
 
 			curoffset += bitlength;
 			if(body[curoffset] != 0)
 			{
 				strcat(domainname, ".");
+				domainlen++;
 			}
 		}
 
@@ -4934,7 +4942,10 @@ void WifiHandler::RXPacketRawToQueue(const RXRawPacketData& rawPacket)
 		if(packetIEEE80211HeaderPtr != NULL)
 		{
 			memset(newRXPacket.rxData, 0, sizeof(newRXPacket.rxData));
-			memcpy(newRXPacket.rxData, packetIEEE80211HeaderPtr, newRXPacket.rxHeader.length);
+			if (newRXPacket.rxHeader.length <= sizeof(newRXPacket.rxData))
+				memcpy(newRXPacket.rxData, packetIEEE80211HeaderPtr, newRXPacket.rxHeader.length);
+			else
+				memcpy(newRXPacket.rxData, packetIEEE80211HeaderPtr, sizeof(newRXPacket.rxData));
 			newRXPacket.latencyCount = 0;
 
 			if(WILLADVANCESEQNO)

--- a/desmume/src/wifi.cpp
+++ b/desmume/src/wifi.cpp
@@ -3141,6 +3141,16 @@ static void SoftAP_RXPacketGet_Callback(u_char* userData, const pcap_pkthdr* pkt
 	}
 
 	RXRawPacketData* rawPacket = (RXRawPacketData*)userData;
+
+	// Calculate emulated packet size before writing
+	const size_t emuPacketSize = (pktHeader->len + (sizeof(WifiDataFrameHeaderDS2STA) + sizeof(WifiLLCSNAPHeader) - sizeof(EthernetFrameHeader)) + 3) & 0xFFFC;
+
+	// Bounds check: ensure we don't overflow the RX buffer
+	if (rawPacket->writeLocation + sizeof(DesmumeFrameHeader) + emuPacketSize > sizeof(rawPacket->buffer))
+	{
+		return;
+	}
+
 	u8* targetPacket = &rawPacket->buffer[rawPacket->writeLocation];
 
 	// Generate the emulator header.
@@ -3148,7 +3158,7 @@ static void SoftAP_RXPacketGet_Callback(u_char* userData, const pcap_pkthdr* pkt
 	strncpy(emulatorHeader.frameID, DESMUME_EMULATOR_FRAME_ID, 8);
 	emulatorHeader.version = DESMUME_EMULATOR_FRAME_CURRENT_VERSION;
 	emulatorHeader.timeStamp = 0;
-	emulatorHeader.emuPacketSize = (pktHeader->len + (sizeof(WifiDataFrameHeaderDS2STA) + sizeof(WifiLLCSNAPHeader) - sizeof(EthernetFrameHeader)) + 3) & 0xFFFC;
+	emulatorHeader.emuPacketSize = emuPacketSize;
 
 	emulatorHeader.packetAttributes.value = 0;
 	emulatorHeader.packetAttributes.IsTXRate20 = 1;
@@ -3332,9 +3342,8 @@ bool AdhocCommInterface::Start(WifiHandler* currentWifiHandler)
 
 	// Create an UDP socket.
 	thisSocket = socket(AF_INET, SOCK_DGRAM, 0);
-	if(thisSocket < 0)
+	if(thisSocket == INVALID_SOCKET)
 	{
-		thisSocket = INVALID_SOCKET;
 
 		// Ad-hoc mode really needs a socket to work at all, so don't even bother
 		// running this comm interface if we didn't get a working socket.
@@ -3429,7 +3438,7 @@ void AdhocCommInterface::Stop()
 {
 	socket_t& thisSocket = *((socket_t*)this->_wifiSocket);
 
-	if(thisSocket >= 0)
+	if(thisSocket != INVALID_SOCKET)
 	{
 		slock_lock(this->_mutexRXThreadRunningFlag);
 
@@ -3461,7 +3470,7 @@ size_t AdhocCommInterface::TXPacketSend(u8* txTargetBuffer, size_t txLength)
 	socket_t& thisSocket = *((socket_t*)this->_wifiSocket);
 	sockaddr_t& thisSendAddr = *((sockaddr_t*)this->_sendAddr);
 
-	if((thisSocket < 0) || (txTargetBuffer == NULL) || (txLength == 0))
+	if((thisSocket == INVALID_SOCKET) || (txTargetBuffer == NULL) || (txLength == 0))
 	{
 		return txPacketSize;
 	}
@@ -3521,7 +3530,7 @@ void AdhocCommInterface::RXPacketGet()
 {
 	socket_t& thisSocket = *((socket_t*)this->_wifiSocket);
 
-	if((thisSocket < 0) || (this->_rawPacket == NULL) || (this->_wifiHandler == NULL))
+	if((thisSocket == INVALID_SOCKET) || (this->_rawPacket == NULL) || (this->_wifiHandler == NULL))
 	{
 		return;
 	}


### PR DESCRIPTION
## Summary

- **Security hardening**: Fix buffer overflows in wifi (DNS, RX packets), GDB stub, CLI args, firmware LZ routines, and ZIP path handling. Replace unsafe `strcpy`/`sprintf`/`sockaddr` casts with bounds-checked alternatives.
- **Memory safety**: Fix memory leak in SPU_Init, GL shader cleanup on failure, GDB stub resource leaks, missing virtual destructor on `GameHackCheat`, and double `NDS_Reset()` in backup import.
- **Performance**: Guard MMU breakpoint scans with `empty()` check on all 6 read/write paths; restore `FORCEINLINE` on SPU hot path.
- **Correctness**: Implement `export_dsv()` for native `.dsv` save export (was silently failing), fix `INVALID_SOCKET` comparison on Windows (WiFi was broken), fix double reset after save import across GTK2/Windows frontends, add `SO_EXCLUSIVEADDRUSE` for GDB port reuse on Windows.
- **CI**: Add native macOS ARM64 build (Apple Silicon NEON-A64 SIMD coverage), fix deprecated/removed MinGW compiler flags (`-fforce-addr`, `-fstrength-reduce`, `-march=pentium4`), fix artifact name typo.
- **Platform**: Define `HOST_WINDOWS` for MinGW builds (`__MINGW32__`/`__MINGW64__`).

## Changed files

18 files changed, 287 insertions(+), 75 deletions(-) across `src/`, `.github/workflows/`, and frontends.

## Test plan

- [ ] Verify CI passes on all platforms (Linux, macOS Intel, macOS ARM64, MinGW)
- [ ] Test GDB stub attach/detach cycle with port reuse
- [ ] Test save import/export for `.dsv`, `.sav`, `.duc`, `.ssp` formats
- [ ] Test WiFi emulation on Windows (INVALID_SOCKET fix)
- [ ] Verify no regressions in normal emulation gameplay