### PR TITLE
fix: bounds check hardening in firmware, ROM reader, and CLI

### DIFF
--- a/desmume/src/ROMReader.cpp
+++ b/desmume/src/ROMReader.cpp
@@ -243,7 +243,7 @@ void * ZIPROMReaderInit(const char * filename)
 
 		memset(tmp2,0,sizeof(tmp2));
 		tmp1 = strndup(filename, strlen(filename) - 4);
-		sprintf(tmp2, "%s/%s", tmp1, dirent->d_name);
+		snprintf(tmp2, sizeof(tmp2), "%s/%s", tmp1, dirent->d_name);
 		free(tmp1);
 		return zzip_fopen(tmp2, "rb");
 	}

--- a/desmume/src/commandline.cpp
+++ b/desmume/src/commandline.cpp
@@ -457,10 +457,10 @@ bool CommandLine::parse(int argc,char **argv)
 		CommonSettings.autodetectBackupMethod = autodetect_method;
 
 	//TODO NOT MAX PRIORITY! change ARM9BIOS etc to be a std::string
-	if(_bios_arm9) { CommonSettings.UseExtBIOS = true; strcpy(CommonSettings.ARM9BIOS,_bios_arm9); }
-	if(_bios_arm7) { CommonSettings.UseExtBIOS = true; strcpy(CommonSettings.ARM7BIOS,_bios_arm7); }
-	#ifndef HOST_WINDOWS 
-		if(_fw_path) { CommonSettings.UseExtFirmware = true; CommonSettings.UseExtFirmwareSettings = true; strcpy(CommonSettings.ExtFirmwarePath,_fw_path); }
+	if(_bios_arm9) { CommonSettings.UseExtBIOS = true; strncpy(CommonSettings.ARM9BIOS,_bios_arm9,sizeof(CommonSettings.ARM9BIOS)-1); CommonSettings.ARM9BIOS[sizeof(CommonSettings.ARM9BIOS)-1]='\0'; }
+	if(_bios_arm7) { CommonSettings.UseExtBIOS = true; strncpy(CommonSettings.ARM7BIOS,_bios_arm7,sizeof(CommonSettings.ARM7BIOS)-1); CommonSettings.ARM7BIOS[sizeof(CommonSettings.ARM7BIOS)-1]='\0'; }
+	#ifndef HOST_WINDOWS
+		if(_fw_path) { CommonSettings.UseExtFirmware = true; CommonSettings.UseExtFirmwareSettings = true; strncpy(CommonSettings.ExtFirmwarePath,_fw_path,sizeof(CommonSettings.ExtFirmwarePath)-1); CommonSettings.ExtFirmwarePath[sizeof(CommonSettings.ExtFirmwarePath)-1]='\0'; }
 	#endif
 	if(_fw_boot) CommonSettings.BootFromFirmware = true;
 	if(_bios_swi) CommonSettings.SWIFromBIOS = true;

--- a/desmume/src/firmware.cpp
+++ b/desmume/src/firmware.cpp
@@ -136,10 +136,24 @@ u32 CFIRMWARE::_decrypt(const u8 *in, u8* &out)
 
 				len = (data >> 12) + 3;
 				offset = (data & 0xFFF);
+
+				// Prevent unsigned underflow: ensure back-reference is within output
+				if (offset >= xOut)
+				{
+					delete[] out;
+					out = NULL;
+					return 0;
+				}
 				windowOffset = (xOut - offset - 1);
 
 				for(j = 0; j < len; j++)
 				{
+					if (xOut >= blockSize || windowOffset >= blockSize)
+					{
+						delete[] out;
+						out = NULL;
+						return 0;
+					}
 					T1WriteByte(out, xOut, T1ReadByte(out, windowOffset));
 					xOut++;
 					windowOffset++;
@@ -150,6 +164,12 @@ u32 CFIRMWARE::_decrypt(const u8 *in, u8* &out)
 			}
 			else
 			{
+				if (xOut >= blockSize)
+				{
+					delete[] out;
+					out = NULL;
+					return 0;
+				}
 				T1WriteByte(out, xOut, T1ReadByte((u8*)curBlock, (xIn % 8)));
 				xOut++;
 				xIn++;
@@ -166,7 +186,7 @@ u32 CFIRMWARE::_decrypt(const u8 *in, u8* &out)
 			d = ((d << 1) & 0xFF);
 		}
 	}
-	
+
 	return (blockSize);
 }
 
@@ -222,10 +242,24 @@ u32 CFIRMWARE::_decompress(const u8 *in, u8* &out)
 
 				len = (data >> 12) + 3;
 				offset = (data & 0xFFF);
+
+				// Prevent unsigned underflow: ensure back-reference is within output
+				if (offset >= xOut)
+				{
+					delete[] out;
+					out = NULL;
+					return 0;
+				}
 				windowOffset = (xOut - offset - 1);
 
 				for(j = 0; j < len; j++)
 				{
+					if (xOut >= blockSize || windowOffset >= blockSize)
+					{
+						delete[] out;
+						out = NULL;
+						return 0;
+					}
 					T1WriteByte(out, xOut, T1ReadByte(out, windowOffset));
 					xOut++;
 					windowOffset++;
@@ -236,6 +270,12 @@ u32 CFIRMWARE::_decompress(const u8 *in, u8* &out)
 			}
 			else
 			{
+				if (xOut >= blockSize)
+				{
+					delete[] out;
+					out = NULL;
+					return 0;
+				}
 				T1WriteByte(out, xOut, T1ReadByte((u8*)curBlock, (xIn % 8)));
 				xOut++;
 				xIn++;
@@ -251,7 +291,7 @@ u32 CFIRMWARE::_decompress(const u8 *in, u8* &out)
 			d = ((d << 1) & 0xFF);
 		}
 	}
-	
+
 	return (blockSize);
 }
 //================================================================================


### PR DESCRIPTION
## Summary

- **firmware.cpp**: Add bounds checks in `_decrypt` and `_decompress` LZ routines (prevents unsigned underflow in back-reference and OOB writes from malformed firmware)
- **ROMReader.cpp**: Replace `sprintf` with `snprintf` for ZIP path construction (prevents stack overflow with long paths or ZIP entry names)
- **commandline.cpp**: Replace `strcpy` with `strncpy` for CLI path arguments

## Files changed

- `desmume/src/firmware.cpp`
- `desmume/src/ROMReader.cpp`
- `desmume/src/commandline.cpp`

## Test plan

- [ ] Test loading firmware images (normal and edge cases)
- [ ] Test loading ROMs from ZIP archives with long file names
- [ ] Test CLI with long path arguments