### PR TITLE
fix: memory safety and performance in core emulation

### DIFF
--- a/desmume/src/MMU.h
+++ b/desmume/src/MMU.h
@@ -722,12 +722,15 @@ FORCEINLINE u8 _MMU_read08(const int PROCNUM, const MMU_ACCESS_TYPE AT, const u3
 #endif
 
 	// break points, wheee
-	for (size_t i = 0; i < memReadBreakPoints.size(); ++i)
+	if (!memReadBreakPoints.empty())
 	{
-		if (addr == memReadBreakPoints[i])
+		for (size_t i = 0; i < memReadBreakPoints.size(); ++i)
 		{
-			execute = false;
-			i = memReadBreakPoints.size();
+			if (addr == memReadBreakPoints[i])
+			{
+				execute = false;
+				break;
+			}
 		}
 	}
 
@@ -770,12 +773,15 @@ FORCEINLINE u16 _MMU_read16(const int PROCNUM, const MMU_ACCESS_TYPE AT, const u
 #endif
 
 	// break points, wheee
-	for (size_t i = 0; i < memReadBreakPoints.size(); ++i)
+	if (!memReadBreakPoints.empty())
 	{
-		if (addr == memReadBreakPoints[i])
+		for (size_t i = 0; i < memReadBreakPoints.size(); ++i)
 		{
-			execute = false;
-			i = memReadBreakPoints.size();
+			if (addr == memReadBreakPoints[i])
+			{
+				execute = false;
+				break;
+			}
 		}
 	}
 
@@ -830,12 +836,15 @@ FORCEINLINE u32 _MMU_read32(const int PROCNUM, const MMU_ACCESS_TYPE AT, const u
     call_registered_interface_mem_hook(addr, 4, HOOK_READ);
 #endif
 	// break points, wheee
-	for (size_t i = 0; i < memReadBreakPoints.size(); ++i)
+	if (!memReadBreakPoints.empty())
 	{
-		if (addr == memReadBreakPoints[i])
+		for (size_t i = 0; i < memReadBreakPoints.size(); ++i)
 		{
-			execute = false;
-			i = memReadBreakPoints.size();
+			if (addr == memReadBreakPoints[i])
+			{
+				execute = false;
+				break;
+			}
 		}
 	}
 
@@ -895,12 +904,15 @@ FORCEINLINE void _MMU_write08(const int PROCNUM, const MMU_ACCESS_TYPE AT, const
 	}
 
 	// break points, wheee
-	for (size_t i = 0; i < memWriteBreakPoints.size(); ++i)
+	if (!memWriteBreakPoints.empty())
 	{
-		if (addr == memWriteBreakPoints[i])
+		for (size_t i = 0; i < memWriteBreakPoints.size(); ++i)
 		{
-			execute = false;
-			i = memWriteBreakPoints.size();
+			if (addr == memWriteBreakPoints[i])
+			{
+				execute = false;
+				break;
+			}
 		}
 	}
 
@@ -953,12 +965,15 @@ FORCEINLINE void _MMU_write16(const int PROCNUM, const MMU_ACCESS_TYPE AT, const
 	}
 
 	// break points, wheee
-	for (size_t i = 0; i < memWriteBreakPoints.size(); ++i)
+	if (!memWriteBreakPoints.empty())
 	{
-		if (addr == memWriteBreakPoints[i])
+		for (size_t i = 0; i < memWriteBreakPoints.size(); ++i)
 		{
-			execute = false;
-			i = memWriteBreakPoints.size();
+			if (addr == memWriteBreakPoints[i])
+			{
+				execute = false;
+				break;
+			}
 		}
 	}
 
@@ -1008,12 +1023,15 @@ FORCEINLINE void _MMU_write32(const int PROCNUM, const MMU_ACCESS_TYPE AT, const
 	}
 
 	// break points, wheee
-	for (size_t i = 0; i < memWriteBreakPoints.size(); ++i)
+	if (!memWriteBreakPoints.empty())
 	{
-		if (addr == memWriteBreakPoints[i])
+		for (size_t i = 0; i < memWriteBreakPoints.size(); ++i)
 		{
-			execute = false;
-			i = memWriteBreakPoints.size();
+			if (addr == memWriteBreakPoints[i])
+			{
+				execute = false;
+				break;
+			}
 		}
 	}
 

--- a/desmume/src/NDSSystem.h
+++ b/desmume/src/NDSSystem.h
@@ -489,6 +489,7 @@ enum MicMode
 
 struct GameHackCheat
 {
+	virtual ~GameHackCheat() = default;
 	virtual void Run() {}
 
 	void write08(u32 address, u8 value);

--- a/desmume/src/OGLRender.cpp
+++ b/desmume/src/OGLRender.cpp
@@ -832,19 +832,24 @@ Render3DError ShaderProgramCreateOGL(GLuint &vtxShaderID,
 		glCompileShader(vtxShaderID);
 		if (!ValidateShaderCompileOGL(GL_VERTEX_SHADER, vtxShaderID))
 		{
-			error = OGLERROR_SHADER_CREATE_ERROR;
-			return error;
+			glDeleteShader(vtxShaderID);
+			vtxShaderID = 0;
+			return OGLERROR_SHADER_CREATE_ERROR;
 		}
 	}
-	
+
 	if (fragShaderID == 0)
 	{
 		fragShaderID = glCreateShader(GL_FRAGMENT_SHADER);
 		if (fragShaderID == 0)
 		{
 			INFO("OpenGL: Failed to create the fragment shader.\n");
-			error = OGLERROR_SHADER_CREATE_ERROR;
-			return error;
+			if (vtxShaderID != 0)
+			{
+				glDeleteShader(vtxShaderID);
+				vtxShaderID = 0;
+			}
+			return OGLERROR_SHADER_CREATE_ERROR;
 		}
 		
 		const char *fragShaderCStringPtr = fragShaderCString;
@@ -852,6 +857,13 @@ Render3DError ShaderProgramCreateOGL(GLuint &vtxShaderID,
 		glCompileShader(fragShaderID);
 		if (!ValidateShaderCompileOGL(GL_FRAGMENT_SHADER, fragShaderID))
 		{
+			glDeleteShader(fragShaderID);
+			fragShaderID = 0;
+			if (vtxShaderID != 0)
+			{
+				glDeleteShader(vtxShaderID);
+				vtxShaderID = 0;
+			}
 			error = OGLERROR_SHADER_CREATE_ERROR;
 			return error;
 		}

--- a/desmume/src/SPU.cpp
+++ b/desmume/src/SPU.cpp
@@ -58,10 +58,10 @@ static inline s8 read_s8(u32 addr) { return (s8)_MMU_read08<ARMCPU_ARM7,MMU_AT_D
 
 #define SPUCHAN_PCM16B_AT(x) ((u32)(x) % SPUINTERPOLATION_TAPS)
 
-//#ifdef FASTBUILD
+#ifdef FASTBUILD
 	#undef FORCEINLINE
 	#define FORCEINLINE
-//#endif
+#endif
 
 //static ISynchronizingAudioBuffer* _currentSynchronizer = metaspu_construct(ESynchMethod_Z);
 static ISynchronizingAudioBuffer* _currentSynchronizer = metaspu_construct(ESynchMethod_N);
@@ -223,6 +223,7 @@ int SPU_Init(int coreid, int newBufferSizeBytes)
 	for (size_t i = 0; i < COSINE_INTERPOLATION_RESOLUTION; i++)
 		cos_lut[i] = (u16)floor((1u<<16) * ((1.0 - cos(((double)i/(double)COSINE_INTERPOLATION_RESOLUTION) * M_PI)) * 0.5));
 
+	delete SPU_core;
 	SPU_core = new SPU_struct((int)ceil(samples_per_hline));
 	SPU_Reset();
 


### PR DESCRIPTION
## Summary

**Memory safety:**
- `SPU.cpp`: Delete `SPU_core` before re-allocation in `SPU_Init` to prevent memory leak
- `OGLRender.cpp`: Clean up GL shaders on compile/create failure paths
- `NDSSystem.h`: Add virtual destructor to polymorphic `GameHackCheat` base class

**Performance:**
- `MMU.h`: Guard breakpoint scan with `empty()` check on all 6 read/write paths
- `SPU.cpp`: Restore `FORCEINLINE` by re-enabling `FASTBUILD` conditional guard

## Files changed

- `desmume/src/SPU.cpp`
- `desmume/src/OGLRender.cpp`
- `desmume/src/NDSSystem.h`
- `desmume/src/MMU.h`

## Test plan

- [ ] Verify no regressions in normal emulation gameplay
- [ ] Test repeated ROM loading (SPU_Init leak fix)
- [ ] Test OpenGL renderer with shader failure scenarios