### PR TITLE
fix: backup save export/import correctness

### DIFF
--- a/desmume/src/frontend/interface/interface.cpp
+++ b/desmume/src/frontend/interface/interface.cpp
@@ -293,9 +293,8 @@ EXPORTED BOOL desmume_backup_import_file(const char *filename, unsigned int forc
 	if (!success) {
         return FALSE;
 	}
-    
-    NDS_Reset();
-	
+
+	// NDS_Reset() is already called inside importData() on success
     return TRUE;
 }
 

--- a/desmume/src/frontend/interface/interface.h
+++ b/desmume/src/frontend/interface/interface.h
@@ -131,7 +131,12 @@ EXPORTED char* desmume_savestate_slot_date(int index);
 EXPORTED BOOL desmume_backup_import_file(const char *filename, unsigned int force_size);
 
 /**
- * Export current battery save to .dsv file.
+ * Export current battery save to file.
+ *
+ * Supported formats (determined by file extension):
+ *   - .dsv  - DeSmuME native save format (raw data + metadata footer)
+ *   - .sav  - Raw save data (no metadata)
+ *   - .sav* - no$GBA format
  *
  * Prerequisites:
  *   - MMU_new.backupDevice is a global object initialized at program startup
@@ -144,7 +149,7 @@ EXPORTED BOOL desmume_backup_import_file(const char *filename, unsigned int forc
  *   // ... play game, save data is created ...
  *   desmume_backup_export_file("backup.dsv");  // Export save data
  *
- * @param filename Destination path for .dsv file
+ * @param filename Destination path (.dsv, .sav, or .sav*)
  * @return TRUE on success, FALSE on failure
  */
 EXPORTED BOOL desmume_backup_export_file(const char *filename);

--- a/desmume/src/frontend/posix/gtk2/main.cpp
+++ b/desmume/src/frontend/posix/gtk2/main.cpp
@@ -1251,7 +1251,7 @@ static void ImportExportBackupDialog(bool is_export)
             gtk_dialog_run(GTK_DIALOG(pDialog));
             gtk_widget_destroy(pDialog);
         } else if (!is_export) {
-            NDS_Reset(); // reboot game
+            // NDS_Reset() is already called inside importData() on success
         }
         g_free(sPath);
         break;

--- a/desmume/src/frontend/windows/importSave.cpp
+++ b/desmume/src/frontend/windows/importSave.cpp
@@ -197,7 +197,7 @@ bool importSave(HWND hwnd, HINSTANCE hAppInst)
 		if (res)
 		{
 			printf("Save was successfully imported\n");
-			NDS_Reset(); // reboot game
+			// NDS_Reset() is already called inside importData() on success
 		}
 		else
 			printf("Save was not successfully imported");

--- a/desmume/src/mc.cpp
+++ b/desmume/src/mc.cpp
@@ -1109,10 +1109,13 @@ bool BackupDevice::exportData(const char *filename)
 	{
 		char tmp[MAX_PATH];
 		memset(tmp, 0, MAX_PATH);
-		strcpy(tmp, filename);
+		strncpy(tmp, filename, MAX_PATH - 1);
 		tmp[strlen(tmp)-1] = 0;
 		return export_no_gba(tmp);
 	}
+
+	if (memcmp(filename + strlen(filename) - 4, ".dsv", 4) == 0)
+		return export_dsv(filename);
 
 	if (memcmp(filename + strlen(filename) - 4, ".sav", 4) == 0)
 		return export_raw(filename);
@@ -1408,6 +1411,45 @@ bool BackupDevice::export_raw(const char* filename)
 	return true;
 }
 
+bool BackupDevice::export_dsv(const char* filename)
+{
+	// Export in native DeSmuME .dsv format (raw data + padding + footer)
+	std::vector<u8> data(this->_fsize);
+	u32 pos = this->_fpMC->ftell();
+	this->_fpMC->fseek(0, SEEK_SET);
+	this->_fpMC->fread((char *)&data[0], this->_fsize);
+	this->_fpMC->fseek(pos, SEEK_SET);
+
+	FILE *outf = fopen(filename, "wb");
+	if (!outf) return false;
+
+	u32 size = (u32)data.size();
+	u32 padSize = pad_up_size(size);
+
+	// Write raw data
+	if (size > 0)
+		fwrite(&data[0], 1, size, outf);
+
+	// Pad to standard save size
+	for (u32 i = size; i < padSize; i++)
+		fputc(uninitializedValue, outf);
+
+	// Write DSV footer (matches the format written by ensure())
+	fprintf(outf, "%s", DESMUME_BACKUP_FOOTER_TXT);
+
+	u32 leVal;
+	leVal = LOCAL_TO_LE_32(size);       fwrite(&leVal, 4, 1, outf);
+	leVal = LOCAL_TO_LE_32(padSize);    fwrite(&leVal, 4, 1, outf);
+	leVal = LOCAL_TO_LE_32(this->_info.type);     fwrite(&leVal, 4, 1, outf);
+	leVal = LOCAL_TO_LE_32(this->_addr_size);     fwrite(&leVal, 4, 1, outf);
+	leVal = LOCAL_TO_LE_32(this->_info.size);     fwrite(&leVal, 4, 1, outf);
+	leVal = LOCAL_TO_LE_32((u32)0);     fwrite(&leVal, 4, 1, outf);  // version
+	fprintf(outf, "%s", kDesmumeSaveCookie);
+
+	fclose(outf);
+	return true;
+}
+
 u32 BackupDevice::pad_up_size(u32 startSize)
 {
 	u32 size = startSize;
@@ -1619,8 +1661,21 @@ bool BackupDevice::import_dsv(const char *filename)
 	}
 	
 	// Read the backup data into memory.
+	// Sanity check: DS save data should never exceed 1 MB
+	if (importFileFooter.info.padSize == 0 || importFileFooter.info.padSize > 1024 * 1024)
+	{
+		fclose(theFile);
+		printf("BackupDevice: DSV import failed! Invalid padSize: %u\n", (unsigned int)importFileFooter.info.padSize);
+		return result;
+	}
 	u8 *backupData = (u8 *)malloc(importFileFooter.info.padSize);
-	
+	if (backupData == NULL)
+	{
+		fclose(theFile);
+		printf("BackupDevice: DSV import failed! Could not allocate %u bytes.\n", (unsigned int)importFileFooter.info.padSize);
+		return result;
+	}
+
 	fseek(theFile, 0, SEEK_SET);
 	const size_t backupDataReadByteCount = fread(backupData, 1, importFileFooter.info.padSize, theFile);
 	fclose(theFile); // At this point, both backup data and footer should have been read, so we can close the import file now.

--- a/desmume/src/mc.h
+++ b/desmume/src/mc.h
@@ -151,6 +151,7 @@ public:
 	bool import_dsv(const char *filename);
 	bool export_no_gba(const char* fname);
 	bool export_raw(const char* filename);
+	bool export_dsv(const char* filename);
 	bool no_gba_unpack(u8 *&buf, u32 &size);
 	
 	bool load_movie(EMUFILE *is);


### PR DESCRIPTION
## Summary

**Backup export:**
- Implement `export_dsv()` for native DeSmuME `.dsv` save export (`exportData` previously silently failed for `.dsv` despite API documentation)
- Add `padSize` validation and `malloc` NULL check in `import_dsv` (prevents crash on malformed `.dsv` files with huge/zero padSize)
- Replace `strcpy` with `strncpy` in `exportData` `.sav` path handling
- Fix documentation to list all supported export formats

**Double NDS_Reset fix (all frontends):**
- Remove redundant `NDS_Reset` after `importData` in GTK2 and Windows frontends (`importData` already calls `NDS_Reset` internally on success)

## Files changed

- `desmume/src/mc.cpp`, `desmume/src/mc.h`
- `desmume/src/frontend/interface/interface.cpp`, `interface.h`
- `desmume/src/frontend/posix/gtk2/main.cpp`
- `desmume/src/frontend/windows/importSave.cpp`

## Test plan

- [ ] Test save import/export for `.dsv`, `.sav`, `.duc`, `.ssp` formats
- [ ] Test importing a malformed `.dsv` with bad padSize
- [ ] Verify single reset after save import on GTK2 and Windows