### PR TITLE
ci: add macOS ARM64 build and update MinGW config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
       - name: buildit
         run: |
           cd desmume/src/frontend/windows/
-          echo "OPT=-fstrength-reduce -fthread-jumps -fcse-follow-jumps -fcse-skip-blocks -frerun-cse-after-loop -fexpensive-optimizations -fforce-addr -fomit-frame-pointer -ffast-math -march=pentium4 -mtune=pentium4 -mmmx -msse2" > config.mak
+          echo "OPT=-fthread-jumps -fcse-follow-jumps -fcse-skip-blocks -frerun-cse-after-loop -fexpensive-optimizations -fomit-frame-pointer -ffast-math -march=x86-64 -mtune=generic -msse2" > config.mak
           make -j8
           mkdir /tmp/DeSmuME
           cp desmume.exe /tmp/DeSmuME
@@ -84,27 +84,58 @@ jobs:
           name: desmume-mingw-win32
           path: /tmp/DeSmuME.tar.xz
 
-  build_macos:
-    name: Build DeSmuME (macOS)
+  build_macos_intel:
+    name: Build DeSmuME (macOS/Intel64)
     runs-on: macos-14
 
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      
+
+      - name: install xcpretty
+        run: gem install xcpretty
+
       - name: xcodebuild
         run: |
           cd desmume/src/frontend/cocoa/
           xcodebuild archive -project "DeSmuME (Latest).xcodeproj" -scheme "DeSmuME (macOS App; Intel64 -- Latest Xcode)" -arch x86_64 -archivePath "$(pwd)/desmume.xcarchive" | xcpretty -c
-      
+
       - name: make zip
         run: |
           cd desmume/src/frontend/cocoa/desmume.xcarchive/Products/Applications/
           7z a DeSmuME.app.zip DeSmuME.app
 
-      - name: Upload artifict
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: macos
+          name: macos-intel64
           path: desmume/src/frontend/cocoa/desmume.xcarchive/Products/Applications/DeSmuME.app.zip
-          if-no-files-found: error 
+          if-no-files-found: error
+
+  build_macos_arm64:
+    name: Build DeSmuME (macOS/AppleSilicon)
+    runs-on: macos-14
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: install xcpretty
+        run: gem install xcpretty
+
+      - name: xcodebuild
+        run: |
+          cd desmume/src/frontend/cocoa/
+          xcodebuild archive -project "DeSmuME (Latest).xcodeproj" -scheme "DeSmuME (macOS App; AppleSilicon -- Latest Xcode)" -arch arm64 -archivePath "$(pwd)/desmume-arm64.xcarchive" | xcpretty -c
+
+      - name: make zip
+        run: |
+          cd desmume/src/frontend/cocoa/desmume-arm64.xcarchive/Products/Applications/
+          7z a DeSmuME.app.zip DeSmuME.app
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-arm64
+          path: desmume/src/frontend/cocoa/desmume-arm64.xcarchive/Products/Applications/DeSmuME.app.zip
+          if-no-files-found: error

--- a/desmume/src/types.h
+++ b/desmume/src/types.h
@@ -28,9 +28,9 @@
 #endif
 
 //analyze microsoft compilers
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__MINGW64__)
 	#define HOST_WINDOWS
-#endif //_MSC_VER
+#endif
 
 // Determine CPU architecture for platforms that don't use the autoconf script
 #if defined(HOST_WINDOWS) || defined(DESMUME_COCOA)


### PR DESCRIPTION
## Summary

**macOS CI:**
- Split `build_macos` into `build_macos_intel` and `build_macos_arm64`
- Add native Apple Silicon build using the AppleSilicon Xcode scheme (previously only x86_64 was built, so NEON-A64 SIMD paths were never tested in CI)
- Add explicit `xcpretty` install step (may not be pre-installed on runners)
- Fix artifact name typo ("artifict" → "artifact")

**MinGW CI:**
- Remove `-fforce-addr` (no-op since GCC 4.8, silently ignored)
- Remove `-fstrength-reduce` (no-op, absorbed into `-O2` in modern GCC)
- Update `-march=pentium4` to `-march=x86-64 -mtune=generic` — open to discussion, happy to revert the `-march` change if 32-bit Pentium 4 (Northwood/early Prescott without EM64T) support is still desired

**Platform:**
- `types.h`: Define `HOST_WINDOWS` for MinGW (`__MINGW32__`/`__MINGW64__`) builds

## Files changed

- `.github/workflows/build.yml`
- `desmume/src/types.h`

## Test plan

- [ ] Verify CI passes on Linux, macOS Intel, macOS ARM64, MinGW
- [ ] Confirm MinGW build produces working binary