### PR TITLE
Set icon for the window

### DIFF
--- a/desmume/src/frontend/posix/gtk/main.ui
+++ b/desmume/src/frontend/posix/gtk/main.ui
@@ -4,6 +4,7 @@
   <object class="GtkApplicationWindow" id="window">
     <property name="can-focus">False</property>
     <property name="title">DeSmuME</property>
+    <property name="icon-name">org.desmume.DeSmuME</property>
     <property name="resizable">True</property>
     <property name="show-menubar">True</property>
     <child>


### PR DESCRIPTION
The window icon is commonly used by taskbars and window managers on X11.