### PR TITLE
Harden save-state and save-file deserialization

### DIFF
--- a/desmume/src/SPU.cpp
+++ b/desmume/src/SPU.cpp
@@ -741,12 +741,14 @@ bool SPUFifo::load(EMUFILE &fp)
 {
 	u32 version;
 	if (fp.read_32LE(version) != 1) return false;
-	fp.read_32LE(head);
-	fp.read_32LE(tail);
-	fp.read_32LE(size);
+	if (version > 1) return false;
+	if (fp.read_32LE(head) != 1) return false;
+	if (fp.read_32LE(tail) != 1) return false;
+	if (fp.read_32LE(size) != 1) return false;
+	if (head < 0 || head >= 16 || tail < 0 || tail >= 16 || size < 0 || size > 16) return false;
 	for (int i = 0; i < 16; i++)
-		fp.read_16LE(buffer[i]);
-	return true;
+		if (fp.read_16LE(buffer[i]) != 1) return false;
+	return !fp.fail();
 }
 
 void SPU_struct::ProbeCapture(int which)
@@ -1986,6 +1988,7 @@ bool spu_loadstate(EMUFILE &is, int size)
 	//read version
 	u32 version;
 	if (is.read_32LE(version) != 1) return false;
+	if (version > 7) return false;
 
 	SPU_struct *spu = SPU_core;
 	reconstruct(&SPU_core->regs);
@@ -1995,14 +1998,15 @@ bool spu_loadstate(EMUFILE &is, int size)
 		channel_struct &chan = spu->channels[j];
 		is.read_32LE(chan.num);
 		is.read_u8(chan.vol);
-		is.read_u8(chan.volumeDiv);
+		if (is.read_u8(chan.volumeDiv) != 1) return false;
 		if (chan.volumeDiv == 4) chan.volumeDiv = 3;
+		if (chan.volumeDiv >= ARRAY_SIZE(volume_shift)) return false;
 		is.read_u8(chan.hold);
 		is.read_u8(chan.pan);
-		is.read_u8(chan.waveduty);
-		is.read_u8(chan.repeat);
-		is.read_u8(chan.format);
-		is.read_u8(chan.status);
+		if (is.read_u8(chan.waveduty) != 1 || chan.waveduty > 7) return false;
+		if (is.read_u8(chan.repeat) != 1 || chan.repeat > 3) return false;
+		if (is.read_u8(chan.format) != 1 || chan.format >= ARRAY_SIZE(format_shift)) return false;
+		if (is.read_u8(chan.status) != 1 || chan.status > CHANSTAT_PLAY) return false;
 		if (version >= 7) is.read_u8(chan.pcm16bOffs); else chan.pcm16bOffs = 0;
 		is.read_32LE(chan.addr);
 		is.read_16LE(chan.timer);
@@ -2047,7 +2051,7 @@ bool spu_loadstate(EMUFILE &is, int size)
 			is.read_16LE(chan.pcm16b[0]); // chan.pcm16b
 			is.fseek(2, SEEK_CUR);        // chan.pcm16b_last
 		}
-		is.read_32LE(chan.index);
+		if (is.read_32LE(chan.index) != 1 || chan.index < 0 || chan.index >= 89) return false;
 		is.read_16LE(chan.x);
 		if (version < 7) is.fseek(2, SEEK_CUR); // chan.psgnoise_last (LE16)
 
@@ -2104,7 +2108,10 @@ bool spu_loadstate(EMUFILE &is, int size)
 	}
 
 	if (version >= 6)
-		for (int i=0;i<2;i++) spu->regs.cap[i].runtime.fifo.load(is);
+	{
+		for (int i=0;i<2;i++)
+			if (!spu->regs.cap[i].runtime.fifo.load(is)) return false;
+	}
 	else
 		for (int i=0;i<2;i++) spu->regs.cap[i].runtime.fifo.reset();
 
@@ -2119,5 +2126,5 @@ bool spu_loadstate(EMUFILE &is, int size)
 	//copy the core spu (the more accurate) to the user spu
 	SPU_CloneUser();
 
-	return true;
+	return !is.fail();
 }

--- a/desmume/src/cheatSystem.cpp
+++ b/desmume/src/cheatSystem.cpp
@@ -1006,29 +1006,9 @@ bool CHEATS::save()
 	return didSave;
 }
 
-char *CHEATS::clearCode(char *s)
-{
-	char	*buf = s;
-	if (!s) return NULL;
-	if (!*s) return s;
-
-	for (u32 i = 0; i < strlen(s); i++)
-	{
-		if (s[i] == ';') break;
-		if (strchr(hexValid, s[i]))
-		{
-			*buf = s[i];
-			buf++;
-		}
-	}
-	*buf = 0;
-	return s;
-}
-
 bool CHEATS::load()
 {
 	bool didLoadAllItems = false;
-	int valueReadResult = 0;
 	
 	if (strlen((const char *)this->_filename) == 0)
 	{
@@ -1047,17 +1027,13 @@ bool CHEATS::load()
 		readSize = CHEAT_FILE_MIN_FGETS_BUFFER;
 	}
 	
-	char *buf = (char *)malloc(readSize);
-	
-	readSize *= sizeof(*buf);
-	
-	std::string		codeStr = "";
-	u32				last = 0;
+	std::vector<char> readBuffer(readSize);
+	char *buf = &readBuffer[0];
+	std::string codeStr;
 	u32				line = 0;
 	
 	INFO("Load cheats: %s\n", this->_filename);
 	clear();
-	last = 0; line = 0;
 	while (!flist.eof())
 	{
 		CHEATS_LIST		tmp_cht;
@@ -1090,8 +1066,14 @@ bool CHEATS::load()
 			continue;
 		}
 		
-		codeStr = (char *)(buf + 5);
-		codeStr = clearCode((char *)codeStr.c_str());
+		const char *description = strchr(buf, ';');
+		const char *codeEnd = (description != NULL) ? description : buf + strlen(buf);
+		codeStr.clear();
+		for (const char *cursor = buf + 5; cursor < codeEnd; cursor++)
+		{
+			if (strchr(hexValid, *cursor) != NULL)
+				codeStr += *cursor;
+		}
 		
 		if (codeStr.empty() || (codeStr.length() % 16 != 0))
 		{
@@ -1100,30 +1082,36 @@ bool CHEATS::load()
 		}
 
 		tmp_cht.enabled = (buf[3] == '0') ? 0 : 1;
-		u32 descr_pos = (u32)std::max<s32>((s32)(strchr((char*)buf, ';') - buf), 0);
-		if (descr_pos != 0)
+		if (description != NULL)
 		{
-			strncpy(tmp_cht.description, (buf + descr_pos + 1), sizeof(tmp_cht.description));
+			strncpy(tmp_cht.description, description + 1, sizeof(tmp_cht.description));
 			tmp_cht.description[sizeof(tmp_cht.description) - 1] = '\0';
 		}
 
-		tmp_cht.num = (u32)codeStr.length() / 16;
+		const size_t codeCount = codeStr.length() / 16;
+		if (codeCount > MAX_XX_CODE)
+		{
+			INFO("Cheats: Too many code values at line %i\n", line);
+			continue;
+		}
+		tmp_cht.num = (u32)codeCount;
 		if ((tmp_cht.type == CHEAT_TYPE_INTERNAL) && (tmp_cht.num > 1))
 		{
-			INFO("Cheats: Too many values for internal cheat\n", line);
+			INFO("Cheats: Too many values for internal cheat at line %i\n", line);
 			continue;
 		}
 
+		bool validCode = true;
 		for (u32 i = 0; i < tmp_cht.num; i++)
 		{
 			char tmp_buf[9] = {0};
 
 			strncpy(tmp_buf, &codeStr[i * 16], 8);
-			valueReadResult = sscanf(tmp_buf, "%x", &tmp_cht.code[i][0]);
-			if (valueReadResult == 0)
+			if (sscanf(tmp_buf, "%x", &tmp_cht.code[i][0]) != 1)
 			{
 				INFO("Cheats: Could not read first value at line %i\n", line);
-				continue;
+				validCode = false;
+				break;
 			}
 
 			if (tmp_cht.type == CHEAT_TYPE_INTERNAL)
@@ -1133,20 +1121,17 @@ bool CHEATS::load()
 			}
 			
 			strncpy(tmp_buf, &codeStr[(i * 16) + 8], 8);
-			valueReadResult = sscanf(tmp_buf, "%x", &tmp_cht.code[i][1]);
-			if (valueReadResult == 0)
+			if (sscanf(tmp_buf, "%x", &tmp_cht.code[i][1]) != 1)
 			{
 				INFO("Cheats: Could not read second value at line %i\n", line);
-				continue;
+				validCode = false;
+				break;
 			}
 		}
+		if (!validCode) continue;
 
 		this->_list.push_back(tmp_cht);
-		last++;
 	}
-	
-	free(buf);
-	buf = NULL;
 
 	INFO("Added %i cheat codes\n", this->_list.size());
 	

--- a/desmume/src/cheatSystem.h
+++ b/desmume/src/cheatSystem.h
@@ -83,8 +83,6 @@ private:
 	u8					_filename[MAX_PATH];
 	size_t				_currentGet;
 
-	char	*clearCode(char *s);
-
 public:
 	CHEATS()
 		: _currentGet(0)

--- a/desmume/src/emufile.cpp
+++ b/desmume/src/emufile.cpp
@@ -457,23 +457,25 @@ size_t EMUFILE::write_buffer(std::vector<u8> &vec)
 	return (size + 4);
 }
 
-size_t EMUFILE::read_buffer(std::vector<u8> &vec)
+size_t EMUFILE::read_buffer(std::vector<u8> &vec, u32 maxSize)
 {
-	u32 size = 0;
-	
-	if (read_32LE(size) != 1)
+	u32 bufferSize = 0;
+
+	if (read_32LE(bufferSize) != 1)
 		return 0;
-	
-	vec.resize(size);
-	
-	if (size > 0)
+
+	const int position = ftell();
+	const int streamSize = size();
+	if (position < 0 || streamSize < position || bufferSize > maxSize || bufferSize > (u32)(streamSize - position))
 	{
-		size_t ret = fread(&vec[0],size);
-		
-		if (ret != size)
-			return 0;
+		_failbit = true;
+		return 0;
 	}
-	
+
+	vec.resize(bufferSize);
+	if (bufferSize > 0 && fread(&vec[0],bufferSize) != bufferSize)
+		return 0;
+
 	return 1;
 }
 
@@ -493,22 +495,27 @@ size_t EMUFILE::write_MemoryStream(EMUFILE_MEMORY &ms)
 
 size_t EMUFILE::read_MemoryStream(EMUFILE_MEMORY &ms)
 {
-	u32 size = 0;
-	
-	if (read_32LE(size) != 1)
+	u32 streamLength = 0;
+
+	if (read_32LE(streamLength) != 1)
 		return 0;
-	
-	if (size > 0)
+
+	const int position = ftell();
+	const int streamSize = size();
+	if (position < 0 || streamSize < position || streamLength > (u32)(streamSize - position))
 	{
-		std::vector<u8> vec(size);
-		size_t ret = fread(&vec[0],size);
-		
-		if (ret != size)
-			return 0;
-		
-		ms.fwrite(&vec[0],size);
+		_failbit = true;
+		return 0;
 	}
-	
+
+	if (streamLength == 0)
+		return 1;
+
+	std::vector<u8> vec(streamLength);
+	if (fread(&vec[0],streamLength) != streamLength)
+		return 0;
+	ms.fwrite(&vec[0],streamLength);
+
 	return 1;
 }
 

--- a/desmume/src/emufile.h
+++ b/desmume/src/emufile.h
@@ -130,7 +130,7 @@ public:
 	float read_floatLE();
 	
 	size_t write_buffer(std::vector<u8> &vec);
-	size_t read_buffer(std::vector<u8> &vec);
+	size_t read_buffer(std::vector<u8> &vec, u32 maxSize = 0xFFFFFFFF);
 	
 	size_t write_MemoryStream(EMUFILE_MEMORY &ms);
 	size_t read_MemoryStream(EMUFILE_MEMORY &ms);

--- a/desmume/src/gfx3d.cpp
+++ b/desmume/src/gfx3d.cpp
@@ -214,6 +214,7 @@ public:
 	{
 		u32 version;
 		if (f.read_32LE(version) != 1) return false;
+		if (version > 2) return false;
 
 		u8 junk8;
 		u32 junk32;
@@ -243,7 +244,7 @@ public:
 			f.read_32LE(paramCounter);
 		}
 
-		return true;
+		return !f.fail();
 	}
 
 } gxf_hardware;
@@ -2391,43 +2392,45 @@ void NDSGeometryEngine::SaveState_v2(EMUFILE &os)
 	}
 }
 
-void NDSGeometryEngine::LoadState_v2(EMUFILE &is)
+bool NDSGeometryEngine::LoadState_v2(EMUFILE &is)
 {
 	u32 loadingIdx;
 	
-	is.read_32LE(loadingIdx);
+	if (is.read_32LE(loadingIdx) != 1 || loadingIdx > 1) return false;
 	this->_mtxStackIndex[MATRIXMODE_PROJECTION] = (u8)loadingIdx;
 	for (size_t j = 0; j < 16; j++)
 	{
-		is.read_32LE(this->_mtxStackProjection[0][j]);
+		if (is.read_32LE(this->_mtxStackProjection[0][j]) != 1) return false;
 	}
 	
-	is.read_32LE(loadingIdx);
+	if (is.read_32LE(loadingIdx) != 1 || loadingIdx > 0x3F) return false;
 	this->_mtxStackIndex[MATRIXMODE_POSITION] = (u8)loadingIdx;
 	for (size_t i = 0; i < NDSMATRIXSTACK_COUNT(MATRIXMODE_POSITION); i++)
 	{
 		for (size_t j = 0; j < 16; j++)
 		{
-			is.read_32LE(this->_mtxStackPosition[i][j]);
+			if (is.read_32LE(this->_mtxStackPosition[i][j]) != 1) return false;
 		}
 	}
 	
-	is.read_32LE(loadingIdx);
+	if (is.read_32LE(loadingIdx) != 1 || loadingIdx > 0x3F) return false;
 	this->_mtxStackIndex[MATRIXMODE_POSITION_VECTOR] = (u8)loadingIdx;
 	for (size_t i = 0; i < NDSMATRIXSTACK_COUNT(MATRIXMODE_POSITION_VECTOR); i++)
 	{
 		for (size_t j = 0; j < 16; j++)
 		{
-			is.read_32LE(this->_mtxStackPositionVector[i][j]);
+			if (is.read_32LE(this->_mtxStackPositionVector[i][j]) != 1) return false;
 		}
 	}
 	
-	is.read_32LE(loadingIdx);
+	if (is.read_32LE(loadingIdx) != 1 || loadingIdx > 1) return false;
 	this->_mtxStackIndex[MATRIXMODE_TEXTURE] = (u8)loadingIdx;
 	for (size_t j = 0; j < 16; j++)
 	{
-		is.read_32LE(this->_mtxStackTexture[0][j]);
+		if (is.read_32LE(this->_mtxStackTexture[0][j]) != 1) return false;
 	}
+
+	return true;
 }
 
 void NDSGeometryEngine::SaveState_v4(EMUFILE &os)
@@ -3952,6 +3955,7 @@ bool gfx3d_loadstate(EMUFILE &is, int size)
 	int version;
 	if (is.read_32LE(version) != 1) return false;
 	if (size == 8) version = 0;
+	if (version < 0 || version > 4) return false;
 
 	if (CurrentRenderer->GetRenderNeedsFinish())
 	{
@@ -3967,7 +3971,7 @@ bool gfx3d_loadstate(EMUFILE &is, int size)
 		float loadingSortYMin = 0.0f;
 		float loadingSortYMax = 0.0f;
 		
-		is.read_32LE(vertListCount32);
+		if (is.read_32LE(vertListCount32) != 1 || vertListCount32 > VERTLIST_SIZE) return false;
 		gfx3d.gList[gfx3d.pendingListIndex].rawVertCount = vertListCount32;
 		gfx3d.gList[gfx3d.appliedListIndex].rawVertCount = vertListCount32;
 		for (size_t i = 0; i < gfx3d.gList[gfx3d.appliedListIndex].rawVertCount; i++)
@@ -3976,7 +3980,7 @@ bool gfx3d_loadstate(EMUFILE &is, int size)
 			gfx3d.gList[gfx3d.appliedListIndex].rawVtxList[i] = gfx3d.gList[gfx3d.pendingListIndex].rawVtxList[i];
 		}
 		
-		is.read_32LE(polyListCount32);
+		if (is.read_32LE(polyListCount32) != 1 || polyListCount32 > POLYLIST_SIZE) return false;
 		gfx3d.gList[gfx3d.pendingListIndex].rawPolyCount = polyListCount32;
 		gfx3d.gList[gfx3d.appliedListIndex].rawPolyCount = polyListCount32;
 		for (size_t i = 0; i < gfx3d.gList[gfx3d.appliedListIndex].rawPolyCount; i++)
@@ -3984,9 +3988,13 @@ bool gfx3d_loadstate(EMUFILE &is, int size)
 			POLY &p = gfx3d.gList[gfx3d.pendingListIndex].rawPolyList[i];
 			
 			GFX3D_LoadStatePOLY(p, is);
-			is.read_32LE(gfx3d.legacySave.rawPolyViewport[i].value);
-			is.read_floatLE(loadingSortYMin);
-			is.read_floatLE(loadingSortYMax);
+			if (is.fail()) return false;
+			if (p.type != POLYGON_TYPE_TRIANGLE && p.type != POLYGON_TYPE_QUAD) return false;
+			for (size_t j = 0; j < (size_t)p.type; j++)
+				if (p.vertIndexes[j] >= vertListCount32) return false;
+			if (is.read_32LE(gfx3d.legacySave.rawPolyViewport[i].value) != 1) return false;
+			if (is.read_floatLE(loadingSortYMin) != 1) return false;
+			if (is.read_floatLE(loadingSortYMax) != 1) return false;
 			
 			p.viewport = GFX3D_ViewportParse(gfx3d.legacySave.rawPolyViewport[i]);
 			gfx3d.rawPolySortYMin[i] = (s64)( (loadingSortYMin * 4096.0f) + 0.5f );
@@ -3998,12 +4006,12 @@ bool gfx3d_loadstate(EMUFILE &is, int size)
 
 	if (version >= 2)
 	{
-		_gEngine.LoadState_v2(is);
+		if (!_gEngine.LoadState_v2(is)) return false;
 	}
 
 	if (version >= 3)
 	{
-		gxf_hardware.loadstate(is);
+		if (!gxf_hardware.loadstate(is)) return false;
 	}
 
 	if (version >= 4)
@@ -4011,6 +4019,28 @@ bool gfx3d_loadstate(EMUFILE &is, int size)
 		_gEngine.LoadState_v4(is);
 	}
 
+	return !is.fail();
+}
+
+bool gfx3d_IsStateValid()
+{
+	const GeometryEngineLegacySave &state = gfx3d.gEngineLegacySave;
+	if (state.mtxCurrentMode > MATRIXMODE_TEXTURE) return false;
+	if (state.mtxLoad4x4PendingIndex >= 16 || state.mtxLoad4x3PendingIndex >= 16) return false;
+	if (state.mtxMultiply4x4TempIndex >= 16 || state.mtxMultiply4x3TempIndex >= 16) return false;
+	if (state.mtxMultiply3x3TempIndex >= 12) return false;
+	if (state.vtxPosition16CurrentIndex >= 2) return false;
+	if (state.vtxFormat > GFX3D_QUAD_STRIP_LINE) return false;
+	if (state.vecTranslateCurrentIndex >= 3 || state.vecScaleCurrentIndex >= 3) return false;
+	if (state.boxTestCoordCurrentIndex > 4 || state.positionTestCoordCurrentIndex > 2) return false;
+	if (state.shininessTablePendingIndex >= 128 || (state.shininessTablePendingIndex & 3) != 0) return false;
+	if (state.vtxCount >= 4) return false;
+	for (size_t i = 0; i < 4; i++)
+		if (state.vtxIndex[i] >= VERTLIST_SIZE) return false;
+
+	if (gxFIFO.head >= HACK_GXIFO_SIZE || gxFIFO.tail >= HACK_GXIFO_SIZE) return false;
+	if (gxFIFO.size > HACK_GXIFO_SIZE || gxFIFO.matrix_stack_op_size > gxFIFO.size) return false;
+	if (gxPIPE.head >= 4 || gxPIPE.tail >= 4 || gxPIPE.size > 4) return false;
 	return true;
 }
 

--- a/desmume/src/gfx3d.h
+++ b/desmume/src/gfx3d.h
@@ -970,7 +970,7 @@ public:
 	void LoadState_LegacyFormat(const GeometryEngineLegacySave &inLegacySave);
 	
 	void SaveState_v2(EMUFILE &os);
-	void LoadState_v2(EMUFILE &is);
+	bool LoadState_v2(EMUFILE &is);
 	
 	void SaveState_v4(EMUFILE &os);
 	void LoadState_v4(EMUFILE &is);
@@ -1015,6 +1015,7 @@ extern SFORMAT SF_GFX3D[];
 void gfx3d_PrepareSaveStateBufferWrite();
 void gfx3d_savestate(EMUFILE &os);
 bool gfx3d_loadstate(EMUFILE &is, int size);
+bool gfx3d_IsStateValid();
 void gfx3d_FinishLoadStateBufferRead();
 
 void gfx3d_ClearStack();

--- a/desmume/src/mc.cpp
+++ b/desmume/src/mc.cpp
@@ -88,6 +88,10 @@ static const u32 saveSizes[] = {512,			// 4k
 								0xFFFFFFFF};
 static const u32 saveSizes_count = ARRAY_SIZE(saveSizes);
 
+static const u32 MAX_NOGBA_PACKED_SIZE = MC_SIZE_512MBITS
+	+ ((MC_SIZE_512MBITS + 126) / 127) + 1;
+static const u32 MAX_NOGBA_FILE_SIZE = 0x50 + MAX_NOGBA_PACKED_SIZE;
+
 //the lookup table from user save types to save parameters
 const SAVE_TYPE save_types[] = {
 	{"Autodetect",		MC_TYPE_AUTODETECT,	1, 0},
@@ -281,7 +285,7 @@ BackupDevice::BackupDevice()
 		{
 			u32 sz = fpTmp.size();
 
-			if (sz > 0)
+			if (sz > 0 && sz <= MAX_NOGBA_FILE_SIZE)
 			{
 				EMUFILE_FILE fpOut = EMUFILE_FILE(_fileName, "wb");
 				if (!fpOut.fail())
@@ -1128,136 +1132,162 @@ bool BackupDevice::exportData(const char *filename)
 const char no_GBA_HEADER_ID[] = "NocashGbaBackupMediaSavDataFile";
 const char no_GBA_HEADER_SRAM_ID[] = "SRAM";
 
+struct NoGbaSaveInfo
+{
+	u32 compressionMethod;
+	u32 packedSize;
+	u32 unpackedSize;
+	size_t dataOffset;
+};
+
+static u32 readNoGbaU32(const u8 *data)
+{
+	u32 value;
+	memcpy(&value, data, sizeof(value));
+	return LE_TO_LOCAL_32(value);
+}
+
+static u16 readNoGbaU16(const u8 *data)
+{
+	u16 value;
+	memcpy(&value, data, sizeof(value));
+	return LE_TO_LOCAL_16(value);
+}
+
+static bool readNoGbaSaveInfo(const u8 *data, size_t dataSize, NoGbaSaveInfo &info)
+{
+	if (data == NULL || dataSize < 0x4C) return false;
+	if (memcmp(data, no_GBA_HEADER_ID, 0x1F) != 0) return false;
+	if (data[0x1F] != 0x1A) return false;
+	if (memcmp(data + 0x40, no_GBA_HEADER_SRAM_ID, 4) != 0) return false;
+
+	info.compressionMethod = readNoGbaU32(data + 0x44);
+	if (info.compressionMethod == 0)
+	{
+		info.packedSize = readNoGbaU32(data + 0x48);
+		info.unpackedSize = info.packedSize;
+		info.dataOffset = 0x4C;
+	}
+	else if (info.compressionMethod == 1)
+	{
+		if (dataSize < 0x50) return false;
+		info.packedSize = readNoGbaU32(data + 0x48);
+		info.unpackedSize = readNoGbaU32(data + 0x4C);
+		info.dataOffset = 0x50;
+
+		const u64 maximumPackedSize = ((u64)info.unpackedSize * 2) + 1;
+		if (info.packedSize == 0 || info.packedSize > MAX_NOGBA_PACKED_SIZE || info.packedSize > maximumPackedSize)
+			return false;
+	}
+	else
+	{
+		return false;
+	}
+
+	return info.unpackedSize > 0 && info.unpackedSize <= MC_SIZE_512MBITS;
+}
+
+static bool hasNoGbaData(const NoGbaSaveInfo &info, size_t dataSize)
+{
+	return info.dataOffset <= dataSize && info.packedSize <= dataSize - info.dataOffset;
+}
+
 u32 BackupDevice::get_save_nogba_size(const char* fname)
 {
 	FILE *fsrc = fopen(fname, "rb");
-	if (fsrc)
-	{
-		char src[0x50] = {0};
-		size_t fsize = 0;
-		fseek(fsrc, 0, SEEK_END);
-		fsize = ftell(fsrc);
-		fseek(fsrc, 0, SEEK_SET);
-		if (fsize < 0x50) { fclose(fsrc); return 0xFFFFFFFF; }
-		memset(&src[0], 0, sizeof(src));
-		if (fread(src, 1, sizeof(src), fsrc) != sizeof(src))  { fclose(fsrc); return 0xFFFFFFFF; }
+	if (fsrc == NULL) return 0xFFFFFFFF;
 
-		for (u8 i = 0; i < 0x1F; i++)
-			if (src[i] != no_GBA_HEADER_ID[i]) { fclose(fsrc); return 0xFFFFFFFF; }
-		if (src[0x1F] != 0x1A) { fclose(fsrc); return 0xFFFFFFFF; }
-		for (int i = 0; i < 0x4; i++)
-			if (src[i+0x40] != no_GBA_HEADER_SRAM_ID[i]) { fclose(fsrc); return 0xFFFFFFFF; }
-		
-		u32 compressMethod = *((u32*)(src+0x44));
-		if (compressMethod == 0)
-			{ fclose(fsrc); return *((u32*)(src+0x48)); }
-		else
-			if (compressMethod == 1)
-				{ fclose(fsrc); return *((u32*)(src+0x4C)); }
+	if (fseek(fsrc, 0, SEEK_END) != 0)
+	{
 		fclose(fsrc);
+		return 0xFFFFFFFF;
 	}
-	return 0xFFFFFFFF;
+
+	const long fileSize = ftell(fsrc);
+	if (fileSize < 0 || (u64)fileSize > MAX_NOGBA_FILE_SIZE || fseek(fsrc, 0, SEEK_SET) != 0)
+	{
+		fclose(fsrc);
+		return 0xFFFFFFFF;
+	}
+
+	u8 header[0x50] = {0};
+	const size_t headerSize = (size_t)fileSize < sizeof(header) ? (size_t)fileSize : sizeof(header);
+	const bool readSucceeded = fread(header, 1, headerSize, fsrc) == headerSize;
+	fclose(fsrc);
+
+	NoGbaSaveInfo info;
+	if (!readSucceeded || !readNoGbaSaveInfo(header, headerSize, info) || !hasNoGbaData(info, (size_t)fileSize))
+		return 0xFFFFFFFF;
+
+	return info.unpackedSize;
 }
 
-u32 BackupDevice::get_save_nogba_size(u8 *data)
+u32 BackupDevice::get_save_nogba_size(const u8 *data, u32 dataSize)
 {
-	for (u8 i = 0; i < 0x1F; i++)
-		if (data[i] != no_GBA_HEADER_ID[i]) return 0xFFFFFFFF;
-	if (data[0x1F] != 0x1A) return 0xFFFFFFFF;
-	for (int i = 0; i < 0x4; i++)
-		if (data[i+0x40] != no_GBA_HEADER_SRAM_ID[i]) return 0xFFFFFFFF;
-	
-	u32 compressMethod = *((u32*)(data+0x44));
-	if (compressMethod == 0)
-		return *((u32*)(data+0x48));
-	if (compressMethod == 1)
-		return *((u32*)(data+0x4C));
-
-	return 0xFFFFFFFF;
+	NoGbaSaveInfo info;
+	if (!readNoGbaSaveInfo(data, dataSize, info) || !hasNoGbaData(info, dataSize)) return 0xFFFFFFFF;
+	return info.unpackedSize;
 }
 
-static int no_gba_unpackSAV(void *in_buf, size_t fsize, void *out_buf, u32 &size)
+static bool no_gba_unpackSAV(const u8 *src, size_t srcSize, u8 *dst, size_t dstCapacity, u32 &size)
 {
-	u8	*src = (u8 *)in_buf;
-	u8	*dst = (u8 *)out_buf;
-	u32 src_pos = 0;
-	u32 dst_pos = 0;
-	u8	cc = 0;
-	u32	size_unpacked = 0;
-	u32	size_packed = 0;
-	u32	compressMethod = 0;
+	NoGbaSaveInfo info;
+	if (!readNoGbaSaveInfo(src, srcSize, info) || !hasNoGbaData(info, srcSize)) return false;
+	if (dst == NULL || info.unpackedSize > dstCapacity) return false;
 
-	if (fsize < 0x50) return (1);
-
-	for (int i = 0; i < 0x1F; i++)
+	if (info.compressionMethod == 0)
 	{
-		if (src[i] != no_GBA_HEADER_ID[i]) return (2);
-	}
-	if (src[0x1F] != 0x1A) return (2);
-	for (int i = 0; i < 0x4; i++)
-	{
-		if (src[i+0x40] != no_GBA_HEADER_SRAM_ID[i]) return (3);
+		memcpy(dst, src + info.dataOffset, info.unpackedSize);
+		size = info.unpackedSize;
+		return true;
 	}
 
-	compressMethod = *((u32*)(src+0x44));
+	size_t srcPos = info.dataOffset;
+	const size_t srcEnd = info.dataOffset + info.packedSize;
+	size_t dstPos = 0;
 
-	if (compressMethod == 0)				// unpacked
+	while (srcPos < srcEnd)
 	{
-		size_unpacked = *((u32*)(src+0x48));
-		src_pos = 0x4C;
-		for (u32 i = 0; i < size_unpacked; i++)
+		const u8 control = src[srcPos++];
+		if (control == 0)
 		{
-			dst[dst_pos++] = src[src_pos++];
+			if (dstPos != info.unpackedSize) return false;
+			size = (u32)dstPos;
+			return true;
 		}
-		size = dst_pos;
-		return (0);
-	}
 
-	if (compressMethod == 1)				// packed (method 1)
-	{
-		size_packed = *((u32*)(src+0x48));
-		size_unpacked = *((u32*)(src+0x4C));
-
-		src_pos = 0x50;
-		while (true)
+		size_t count;
+		if (control == 0x80)
 		{
-			cc = src[src_pos++];
-			
-			if (cc == 0) 
-			{
-				size = dst_pos;
-				return (0);
-			}
-
-			if (cc == 0x80)
-			{
-				u16 tsize = *((u16*)(src+src_pos+1));
-				for (int t = 0; t < tsize; t++)
-					dst[dst_pos++] = src[src_pos];
-				src_pos += 3;
-				continue;
-			}
-
-			if (cc > 0x80)		// repeat
-			{
-				cc -= 0x80;
-				for (int t = 0; t < cc; t++)
-					dst[dst_pos++] = src[src_pos];
-				src_pos++;
-				continue;
-			}
-			// copy
-			for (int t = 0; t < cc; t++)
-				dst[dst_pos++] = src[src_pos++];
+			if (srcEnd - srcPos < 3) return false;
+			count = readNoGbaU16(src + srcPos + 1);
+			if (count == 0 || count > info.unpackedSize - dstPos) return false;
+			memset(dst + dstPos, src[srcPos], count);
+			srcPos += 3;
 		}
-		size = dst_pos;
-		return (0);
+		else if (control > 0x80)
+		{
+			count = control - 0x80;
+			if (srcPos >= srcEnd || count > info.unpackedSize - dstPos) return false;
+			memset(dst + dstPos, src[srcPos++], count);
+		}
+		else
+		{
+			count = control;
+			if (count > srcEnd - srcPos || count > info.unpackedSize - dstPos) return false;
+			memcpy(dst + dstPos, src + srcPos, count);
+			srcPos += count;
+		}
+		dstPos += count;
 	}
-	return (200);
+
+	return false;
 }
 
 u32 BackupDevice::trim(void *buf, u32 size)
 {
+	if (buf == NULL || size < 16) return size;
+
 	u32 rows = size / 16;
 	u32 pos = (size - 16);
 	u8	*src = (u8*)buf;
@@ -1291,66 +1321,86 @@ u32 BackupDevice::fillLeft(u32 size)
 
 bool BackupDevice::import_no_gba(const char *fname, u32 force_size)
 {
-	FILE	*fsrc = fopen(fname, "rb");
-	u8		*in_buf = NULL;
-	u8		*out_buf = NULL;
+	FILE *fsrc = fopen(fname, "rb");
+	if (fsrc == NULL) return false;
 
-	if (fsrc)
+	if (fseek(fsrc, 0, SEEK_END) != 0)
 	{
-		size_t fsize = 0;
-		fseek(fsrc, 0, SEEK_END);
-		fsize = ftell(fsrc);
-		fseek(fsrc, 0, SEEK_SET);
-		//printf("Open %s file (size %i bytes)\n", fname, fsize);
-
-		in_buf = new u8 [fsize];
-
-		if (fread(in_buf, 1, fsize, fsrc) == fsize)
-		{
-			out_buf = new u8 [8 * 1024 * 1024 / 8];
-			u32 size = 0;
-
-			memset(out_buf, 0xFF, 8 * 1024 * 1024 / 8);
-			if (no_gba_unpackSAV(in_buf, fsize, out_buf, size) == 0)
-			{
-				if (force_size > 0)
-					size = force_size;
-				//printf("New size %i byte(s)\n", size);
-				size = trim(out_buf, size);
-				//printf("--- new size after trim %i byte(s)\n", size);
-				size = fillLeft(size);
-				//printf("--- new size after fill %i byte(s)\n", size);
-				raw_applyUserSettings(size, (force_size > 0));
-				saveBuffer(out_buf, size, true, true);
-
-				if (in_buf) delete [] in_buf;
-				if (out_buf) delete [] out_buf;
-				fclose(fsrc);
-				return true;
-			}
-			if (out_buf) delete [] out_buf;
-		}
-		if (in_buf) delete [] in_buf;
 		fclose(fsrc);
+		return false;
 	}
-	return false;
+
+	const long fileSize = ftell(fsrc);
+	if (fileSize < 0 || (u64)fileSize > MAX_NOGBA_FILE_SIZE || fseek(fsrc, 0, SEEK_SET) != 0)
+	{
+		fclose(fsrc);
+		return false;
+	}
+
+	u8 header[0x50] = {0};
+	const size_t headerSize = (size_t)fileSize < sizeof(header) ? (size_t)fileSize : sizeof(header);
+	if (fread(header, 1, headerSize, fsrc) != headerSize)
+	{
+		fclose(fsrc);
+		return false;
+	}
+
+	NoGbaSaveInfo info;
+	if (!readNoGbaSaveInfo(header, headerSize, info) || !hasNoGbaData(info, (size_t)fileSize))
+	{
+		fclose(fsrc);
+		return false;
+	}
+
+	const size_t inputSize = info.dataOffset + info.packedSize;
+	std::vector<u8> input(inputSize);
+	if (fseek(fsrc, 0, SEEK_SET) != 0 || fread(&input[0], 1, inputSize, fsrc) != inputSize)
+	{
+		fclose(fsrc);
+		return false;
+	}
+	fclose(fsrc);
+
+	if (force_size > MC_SIZE_512MBITS) return false;
+	const u32 requestedSize = force_size > info.unpackedSize ? force_size : info.unpackedSize;
+	const u32 outputCapacity = fillLeft(requestedSize);
+	if (outputCapacity < info.unpackedSize || outputCapacity > MC_SIZE_512MBITS) return false;
+
+	std::vector<u8> output(outputCapacity, 0xFF);
+	u32 size = 0;
+	if (!no_gba_unpackSAV(&input[0], input.size(), &output[0], output.size(), size)) return false;
+
+	if (force_size > 0) size = force_size;
+	size = fillLeft(trim(&output[0], size));
+	if (size > output.size()) return false;
+
+	raw_applyUserSettings(size, (force_size > 0));
+	if (size > output.size()) return false;
+	saveBuffer(&output[0], size, true, true);
+	return true;
 }
 
 bool BackupDevice::no_gba_unpack(u8 *&buf, u32 &size)
 {
 	if (!buf) return false;
-	u32 out_size = get_save_nogba_size(buf);
-	if (out_size == 0xFFFFFFFF) return false;
-	u8 *out_buf = new u8 [out_size];
-	if (out_buf)
+	const u32 unpackedSize = get_save_nogba_size(buf, size);
+	if (unpackedSize == 0xFFFFFFFF) return false;
+
+	const u32 outputCapacity = fillLeft(unpackedSize);
+	if (outputCapacity < unpackedSize || outputCapacity > MC_SIZE_512MBITS) return false;
+
+	u8 *out_buf = new u8 [outputCapacity];
+	memset(out_buf, 0xFF, outputCapacity);
+
+	u32 outSize = 0;
+	if (no_gba_unpackSAV(buf, size, out_buf, outputCapacity, outSize))
 	{
-		if (no_gba_unpackSAV(buf, size, out_buf, out_size) == 0)
+		outSize = fillLeft(trim(out_buf, outSize));
+		if (outSize <= outputCapacity)
 		{
-			out_size = trim(out_buf, out_size);
-			out_size = fillLeft(out_size);
 			delete [] buf;
 			buf = out_buf;
-			size = out_size;
+			size = outSize;
 			return true;
 		}
 	}

--- a/desmume/src/mc.cpp
+++ b/desmume/src/mc.cpp
@@ -163,34 +163,42 @@ bool BackupDevice::load_state(EMUFILE &is)
 	std::vector<u8> data;
 
 	if (is.read_32LE(version) != 1) return false;
+	if (version > 5) return false;
 
-	is.read_bool32(this->_write_enable);
-	is.read_32LE(this->_com);
-	is.read_32LE(this->_addr_size);
-	is.read_32LE(this->_addr_counter);
-	is.read_32LE(temp);
+	if (is.read_bool32(this->_write_enable) != 1) return false;
+	if (is.read_32LE(this->_com) != 1) return false;
+	if (is.read_32LE(this->_addr_size) != 1) return false;
+	if (is.read_32LE(this->_addr_counter) != 1) return false;
+	if (is.read_32LE(temp) != 1 || temp > RUNNING) return false;
 	this->_state = (STATE)temp;
-	is.read_buffer(data);
-	is.read_buffer(this->_data_autodetect);
+	if (is.read_buffer(data, MC_SIZE_512MBITS) != 1) return false;
+	if (is.read_buffer(this->_data_autodetect, MC_SIZE_512MBITS) != 1) return false;
+	if (this->_addr_size > 4 || this->_addr_counter > this->_addr_size) return false;
 
 	if (version >= 1)
-		is.read_32LE(this->_addr);
+	{
+		if (is.read_32LE(this->_addr) != 1) return false;
+	}
 	
 	if (version >= 2)
 	{
-		is.read_u8(this->_motionInitState);
-		is.read_u8(this->_motionFlag);
+		if (is.read_u8(this->_motionInitState) != 1) return false;
+		if (is.read_u8(this->_motionFlag) != 1) return false;
 	}
 
 	if (version >= 3)
 	{
-		is.read_bool32(this->_reset_command_state);
+		if (is.read_bool32(this->_reset_command_state) != 1) return false;
 	}
 
 	if (version >= 4)
 	{
-		is.read_u8(this->_write_protect);
+		if (is.read_u8(this->_write_protect) != 1) return false;
 	}
+
+	u32 savePosition = this->_addr;
+	if (version >= 5 && is.read_32LE(savePosition) != 1) return false;
+	if (savePosition > data.size()) return false;
 
 	this->_fsize = (u32)data.size();
 #ifndef _DONT_SAVE_BACKUP
@@ -200,15 +208,9 @@ bool BackupDevice::load_state(EMUFILE &is)
 	ensure((u32)data.size(), this->_fpMC);
 #endif
 
-	if (version >= 5)
-	{
-		is.read_32LE(temp);
-		this->_fpMC->fseek(temp, SEEK_SET);
-	}
-	else
-		this->_fpMC->fseek(this->_addr, SEEK_SET);
+	this->_fpMC->fseek(savePosition, SEEK_SET);
 
-	return true;
+	return !is.fail();
 }
 
 BackupDevice::BackupDevice()

--- a/desmume/src/mc.h
+++ b/desmume/src/mc.h
@@ -143,7 +143,7 @@ public:
 
 	u32 get_save_duc_size(const char* filename);
 	u32 get_save_nogba_size(const char* filename);
-	u32 get_save_nogba_size(u8 *data);
+	u32 get_save_nogba_size(const u8 *data, u32 dataSize);
 	u32 get_save_raw_size(const char* filename);
 	bool import_duc(const char* filename, u32 force_size = 0);
 	bool import_no_gba(const char *fname, u32 force_size = 0);

--- a/desmume/src/saves.cpp
+++ b/desmume/src/saves.cpp
@@ -76,6 +76,122 @@ savestates_t savestates[NB_STATES];
 
 #define SAVESTATE_VERSION       12
 static const char* magic = "DeSmuME SState\0";
+static const u32 MAX_SAVESTATE_SIZE = 256U * 1024U * 1024U;
+
+class SavestateChunkStream : public EMUFILE
+{
+private:
+	const u8 *data;
+	int dataSize;
+	int position;
+
+public:
+	SavestateChunkStream(const std::vector<u8> &buffer)
+		: data(buffer.empty() ? NULL : &buffer[0]), dataSize((int)buffer.size()), position(0)
+	{
+	}
+
+	virtual EMUFILE* memwrap()
+	{
+		EMUFILE_MEMORY *stream = new EMUFILE_MEMORY((void *)data, dataSize);
+		stream->fseek(position, SEEK_SET);
+		return stream;
+	}
+
+	virtual FILE* get_fp() { return NULL; }
+
+	virtual int fprintf(const char *, ...)
+	{
+		_failbit = true;
+		return -1;
+	}
+
+	virtual int fgetc()
+	{
+		if (position >= dataSize)
+			return EOF;
+		return data[position++];
+	}
+
+	virtual int fputc(int)
+	{
+		_failbit = true;
+		return EOF;
+	}
+
+	virtual char* fgets(char *str, int num)
+	{
+		if (str == NULL || num <= 0)
+		{
+			_failbit = true;
+			return NULL;
+		}
+
+		if (position >= dataSize)
+			return NULL;
+
+		int copied = 0;
+		while (copied < num - 1 && position < dataSize)
+		{
+			const char value = (char)data[position++];
+			str[copied++] = value;
+			if (value == '\n')
+				break;
+		}
+		str[copied] = '\0';
+		return str;
+	}
+
+	virtual size_t _fread(const void *ptr, size_t bytes)
+	{
+		const size_t remaining = (size_t)(dataSize - position);
+		const size_t bytesToRead = std::min(bytes, remaining);
+		if (bytesToRead > 0)
+			memcpy((void *)ptr, data + position, bytesToRead);
+		position += (int)bytesToRead;
+		if (bytesToRead != bytes)
+			_failbit = true;
+		return bytesToRead;
+	}
+
+	virtual size_t fwrite(const void *, size_t)
+	{
+		_failbit = true;
+		return 0;
+	}
+
+	virtual int fseek(int offset, int origin)
+	{
+		s64 target;
+		switch (origin)
+		{
+			case SEEK_SET: target = offset; break;
+			case SEEK_CUR: target = (s64)position + offset; break;
+			case SEEK_END: target = (s64)dataSize + offset; break;
+			default:
+				_failbit = true;
+				return -1;
+		}
+
+		if (target < 0 || target > dataSize)
+		{
+			_failbit = true;
+			return -1;
+		}
+
+		position = (int)target;
+		return 0;
+	}
+
+	virtual int ftell() { return position; }
+	virtual int size() { return dataSize; }
+	virtual void fflush() {}
+
+	virtual void truncate(s32)
+	{
+		_failbit = true;
+	}
+};
 
 //a savestate chunk loader can set this if it wants to permit a silent failure (for compatibility)
 static bool SAV_silent_fail_flag;
@@ -422,7 +538,7 @@ static bool s_slot1_loadstate(EMUFILE &is, int size)
 	slot1_Change(slot1Type);
 
 	EMUFILE_MEMORY temp;
-	is.read_MemoryStream(temp);
+	if (is.read_MemoryStream(temp) != 1) return false;
 	temp.fseek(0, SEEK_SET);
 	slot1_Loadstate(temp);
 
@@ -454,7 +570,7 @@ static bool s_slot2_loadstate(EMUFILE &is, int size)
 	slot2_Change(slot2Type);
 
 	EMUFILE_MEMORY temp;
-	is.read_MemoryStream(temp);
+	if (is.read_MemoryStream(temp) != 1) return false;
 	temp.fseek(0, SEEK_SET);
 	slot2_Loadstate(temp);
 
@@ -510,6 +626,10 @@ static void mmu_savestate(EMUFILE &os)
 
 static bool mmu_loadstate(EMUFILE &is, int size)
 {
+	if (size < 0) return false;
+	const int chunkStart = is.ftell();
+	if (chunkStart < 0) return false;
+
 	//read version
 	u32 version;
 	if (is.read_32LE(version) != 1) return false;
@@ -541,12 +661,17 @@ static bool mmu_loadstate(EMUFILE &is, int size)
 
 		if (addr_size == 0xFFFFFFFF)
 			return false;
+		if (bupmem_size > MC_SIZE_512MBITS || bupmem_size > (u32)(is.size() - is.ftell()))
+			return false;
 
 		u8 *temp = new u8[bupmem_size];
-		is.fread(temp,bupmem_size);
+		if (is.fread(temp,bupmem_size) != bupmem_size)
+		{
+			delete[] temp;
+			return false;
+		}
 		MMU_new.backupDevice.load_old_state(addr_size,temp,bupmem_size);
 		delete[] temp;
-		if (is.fail()) return false;
 	}
 
 	if (version < 2) return true;
@@ -595,9 +720,17 @@ static bool mmu_loadstate(EMUFILE &is, int size)
 	if (version < 8) return ok;
 
 	//version 8:
-	memset(MMU.fw.data._raw, 0, sizeof(NDSFirmwareData));
-	MMU.fw.size = is.read_u32LE();
-	is.fread(MMU.fw.data._raw, MMU.fw.size);
+	u32 firmwareSize;
+	if (is.read_32LE(firmwareSize) != 1) return false;
+
+	const int bytesRead = is.ftell() - chunkStart;
+	if (bytesRead < 0 || bytesRead > size) return false;
+	if (firmwareSize > sizeof(MMU.fw.data._raw)
+		|| firmwareSize > (u32)(size - bytesRead)) return false;
+
+	memset(MMU.fw.data._raw, 0, sizeof(MMU.fw.data._raw));
+	if (is.fread(MMU.fw.data._raw, firmwareSize) != firmwareSize) return false;
+	MMU.fw.size = firmwareSize;
 	
 	return ok;
 }
@@ -884,19 +1017,28 @@ static bool ReadStateChunk(EMUFILE &is, const SFORMAT *sf, int size)
 {
 	const SFORMAT *tmp = NULL;
 	const SFORMAT *guessSF = NULL;
-	int temp = is.ftell();
+	const int start = is.ftell();
+	if (start < 0 || size < 0 || size > is.size() - start)
+		return false;
+	const int end = start + size;
 
-	while (is.ftell() < (temp+size))
+	while (is.ftell() < end)
 	{
+		if (is.ftell() < 0 || end - is.ftell() < 12)
+			return false;
+
 		u32 sz, count;
 
 		char toa[4];
-		is.fread(toa,4);
-		if (is.fail())
+		if (is.fread(toa,4) != 4)
 			return false;
 
 		if (!is.read_32LE(sz)) return false;
 		if (!is.read_32LE(count)) return false;
+
+		const u64 dataSize = (u64)sz * count;
+		if (dataSize > (u64)(end - is.ftell()))
+			return false;
 		
 		tmp = CheckS(guessSF,sf,sz,count,toa);
 		
@@ -906,29 +1048,29 @@ static bool ReadStateChunk(EMUFILE &is, const SFORMAT *sf, int size)
 			if (sz == 1)
 			{
 				//special case: read a huge byte array
-				is.fread(tmp->v,count);
+				if (is.fread(tmp->v,count) != count) return false;
 			}
 			else
 			{
 				for (size_t i = 0; i < count; i++)
 				{
-					is.fread((u8 *)tmp->v + i*sz,sz);
+					if (is.fread((u8 *)tmp->v + i*sz,sz) != sz) return false;
                     FlipByteOrder((u8 *)tmp->v + i*sz,sz);
 				}
 			}
 		#else
 			// no need to ever loop one at a time if not flipping byte order
-			is.fread(tmp->v,sz*count);
+			if (is.fread(tmp->v,(size_t)dataSize) != dataSize) return false;
 		#endif
 			guessSF = tmp + 1;
 		}
 		else
 		{
-			is.fseek(sz*count,SEEK_CUR);
+			if (is.fseek((int)dataSize,SEEK_CUR) != 0) return false;
 			guessSF = NULL;
 		}
 	} // while(...)
-	return true;
+	return is.ftell() == end;
 }
 
 
@@ -1193,6 +1335,13 @@ static bool ReadStateChunks(EMUFILE &is, s32 totalsize)
 	bool ret = true;
 	bool haveInfo = false;
 	bool chunkError = false;
+	bool foundTerminator = false;
+
+	const int stateStart = is.ftell();
+	const int streamSize = is.size();
+	if (stateStart < 0 || streamSize < stateStart || totalsize < 0 || totalsize > streamSize - stateStart)
+		return false;
+	const int stateEnd = stateStart + totalsize;
 	
 	s64 save_time = 0;
 	u32 romsize = 0;
@@ -1213,42 +1362,54 @@ static bool ReadStateChunks(EMUFILE &is, s32 totalsize)
 	};
 	memset(&header, 0, sizeof(header));
 
-	while (totalsize > 0)
+	while (is.ftell() < stateEnd)
 	{
 		u32 size = 0;
 		u32 t = 0;
-		if (!is.read_32LE(t))  { ret=false; break; }
-		if (t == 0xFFFFFFFF) break;
-		if (!is.read_32LE(size))  { ret=false; break; }
-		u32 endPos = is.ftell() + size;
+		if (stateEnd - is.ftell() < 4 || !is.read_32LE(t))
+			return false;
+		if (t == 0xFFFFFFFF)
+		{
+			foundTerminator = true;
+			break;
+		}
+		if (stateEnd - is.ftell() < 4 || !is.read_32LE(size))
+			return false;
+		if (size > (u32)(stateEnd - is.ftell()))
+			return false;
+
+		std::vector<u8> chunkData(size);
+		if (size > 0 && is.fread(&chunkData[0], size) != size)
+			return false;
+		SavestateChunkStream chunk(chunkData);
 		
 		switch(t)
 		{
-			case 1: if(!ReadStateChunk(is,SF_ARM9,size)) ret=false; break;
-			case 2: if(!ReadStateChunk(is,SF_ARM7,size)) ret=false; break;
-			case 3: if(!cp15_loadstate(is,size)) ret=false; break;
-			case 4: if(!ReadStateChunk(is,SF_MEM,size)) ret=false; break;
-			case 5: if(!ReadStateChunk(is,SF_NDS,size)) ret=false; break;
-			case 51: if(!nds_loadstate(is,size)) ret=false; break;
-			case 60: if(!ReadStateChunk(is,SF_MMU,size)) ret=false; break;
-			case 61: if(!mmu_loadstate(is,size)) ret=false; break;
-			case 7: if(!gpu_loadstate(is,size)) ret=false; break;
-			case 8: if(!spu_loadstate(is,size)) ret=false; break;
-			case 81: if(!mic_loadstate(is,size)) ret=false; break;
-			case 90: if(!ReadStateChunk(is,SF_GFX3D,size)) ret=false; break;
-			case 91: if(!gfx3d_loadstate(is,size)) ret=false; break;
-			case 100: if(!ReadStateChunk(is,SF_MOVIE, size)) ret=false; break;
-			case 101: if(!mov_loadstate(is, size)) ret=false; break;
-			case 111: if(!wifiHandler->LoadState(is,size)) ret=false; break;
-			case 120: if(!ReadStateChunk(is,SF_RTC,size)) ret=false; break;
-			case 130: if(!ReadStateChunk(is,SF_INFO,size)) ret=false; else haveInfo=true; break;
-			case 140: if(!s_slot1_loadstate(is, size)) ret=false; break;
-			case 150: if(!s_slot2_loadstate(is, size)) ret=false; break;
+			case 1: if(!ReadStateChunk(chunk,SF_ARM9,size)) ret=false; break;
+			case 2: if(!ReadStateChunk(chunk,SF_ARM7,size)) ret=false; break;
+			case 3: if(!cp15_loadstate(chunk,size)) ret=false; break;
+			case 4: if(!ReadStateChunk(chunk,SF_MEM,size)) ret=false; break;
+			case 5: if(!ReadStateChunk(chunk,SF_NDS,size)) ret=false; break;
+			case 51: if(!nds_loadstate(chunk,size)) ret=false; break;
+			case 60: if(!ReadStateChunk(chunk,SF_MMU,size)) ret=false; break;
+			case 61: if(!mmu_loadstate(chunk,size)) ret=false; break;
+			case 7: if(!gpu_loadstate(chunk,size)) ret=false; break;
+			case 8: if(!spu_loadstate(chunk,size)) ret=false; break;
+			case 81: if(!mic_loadstate(chunk,size)) ret=false; break;
+			case 90: if(!ReadStateChunk(chunk,SF_GFX3D,size)) ret=false; break;
+			case 91: if(!gfx3d_loadstate(chunk,size)) ret=false; break;
+			case 100: if(!ReadStateChunk(chunk,SF_MOVIE, size)) ret=false; break;
+			case 101: if(!mov_loadstate(chunk, size)) ret=false; break;
+			case 111: if(!wifiHandler->LoadState(chunk,size)) ret=false; break;
+			case 120: if(!ReadStateChunk(chunk,SF_RTC,size)) ret=false; break;
+			case 130: if(!ReadStateChunk(chunk,SF_INFO,size)) ret=false; else haveInfo=true; break;
+			case 140: if(!s_slot1_loadstate(chunk, size)) ret=false; break;
+			case 150: if(!s_slot2_loadstate(chunk, size)) ret=false; break;
 			// reserved for future versions
 			case 160:
 			case 170:
 			case 180:
-				if(!ReadStateChunk(is,reserveChunks,size)) ret=false;
+				if(!ReadStateChunk(chunk,reserveChunks,size)) ret=false;
 			break;
 			// ============================
 				
@@ -1256,16 +1417,31 @@ static bool ReadStateChunks(EMUFILE &is, s32 totalsize)
 				return false;
 		}
 		
-		if (is.ftell() != endPos)
+		if (chunk.fail())
+			return false;
+
+		if (chunk.ftell() != (int)size)
 		{
-			// Should we just go ahead and return false?
 			chunkError = true;
-			is.fseek(endPos, SEEK_SET);
 		}
 		
 		if(!ret)
 			return false;
 	}
+
+	if (!foundTerminator || is.ftell() != stateEnd)
+		return false;
+	for (size_t i = 0; i < ARRAY_SIZE(ipc_fifo); i++)
+	{
+		if (ipc_fifo[i].head >= ARRAY_SIZE(ipc_fifo[i].buf)
+			|| ipc_fifo[i].tail >= ARRAY_SIZE(ipc_fifo[i].buf)
+			|| ipc_fifo[i].size > ARRAY_SIZE(ipc_fifo[i].buf))
+			return false;
+	}
+	if (disp_fifo.head >= ARRAY_SIZE(disp_fifo.buf) || disp_fifo.tail >= ARRAY_SIZE(disp_fifo.buf))
+		return false;
+	if (!gfx3d_IsStateValid())
+		return false;
 	
 	if (chunkError)
 	{
@@ -1349,19 +1525,26 @@ bool savestate_load(EMUFILE &is)
 {
 	SAV_silent_fail_flag = false;
 	char header[16];
-	is.fread(header,16);
-	if (is.fail() || memcmp(header,magic,16))
+	if (is.fread(header,16) != 16 || memcmp(header,magic,16))
 		return false;
 
-	u32 ssversion,len,comprlen;
+	u32 ssversion, desmumeVersion, len, comprlen;
 	if (!is.read_32LE(ssversion)) return false;
-	if (!is.read_32LE(_DESMUME_version)) return false;
+	if (!is.read_32LE(desmumeVersion)) return false;
 	if (!is.read_32LE(len)) return false;
 	if (!is.read_32LE(comprlen)) return false;
 
 	if (ssversion != SAVESTATE_VERSION) return false;
+	if (len == 0 || len > MAX_SAVESTATE_SIZE) return false;
 
-	std::vector<u8> buf(len);
+	u32 payloadSize = len;
+	const int inputPosition = is.ftell();
+	const int inputSize = is.size();
+	if (inputPosition < 0 || inputSize < inputPosition)
+		return false;
+	const u32 inputRemaining = (u32)(inputSize - inputPosition);
+
+	std::vector<u8> buf;
 
 	if (comprlen != 0xFFFFFFFF)
 	{
@@ -1369,21 +1552,31 @@ bool savestate_load(EMUFILE &is)
 		//without libz, we can't decompress this savestate
 		return false;
 #endif
-		std::vector<char> cbuf(comprlen);
-		is.fread(&cbuf[0],comprlen);
-		if (is.fail()) return false;
+		if (comprlen == 0 || comprlen > MAX_SAVESTATE_SIZE || comprlen > inputRemaining)
+			return false;
+		std::vector<u8> cbuf(comprlen);
+		buf.resize(payloadSize);
+		if (is.fread(&cbuf[0],comprlen) != comprlen) return false;
 
 #ifdef HAVE_LIBZ
 		uLongf uncomprlen = len;
-		int error = uncompress((u8*)&buf[0],&uncomprlen,(u8*)&cbuf[0],comprlen);
+		int error = uncompress(&buf[0],&uncomprlen,&cbuf[0],comprlen);
 		if (error != Z_OK || uncomprlen != len)
 			return false;
 #endif
 	}
 	else
 	{
-		is.fread(&buf[0],len-32);
+		if (len < 32)
+			return false;
+		payloadSize = len - 32;
+		if (payloadSize == 0 || payloadSize > inputRemaining)
+			return false;
+		buf.resize(payloadSize);
+		if (is.fread(&buf[0],payloadSize) != payloadSize) return false;
 	}
+
+	_DESMUME_version = desmumeVersion;
 
 	//GO!! READ THE SAVESTATE
 	//THERE IS NO GOING BACK NOW
@@ -1407,7 +1600,7 @@ bool savestate_load(EMUFILE &is)
 	//SPU_Reset();
 
 	EMUFILE_MEMORY mstemp(&buf);
-	bool x = ReadStateChunks(mstemp,(s32)len);
+	bool x = ReadStateChunks(mstemp,(s32)payloadSize);
 
 	if (!x && !SAV_silent_fail_flag)
 	{


### PR DESCRIPTION
## Summary

This hardens three file-loading paths that accepted untrusted sizes and indices without sufficient validation:

- save-state deserialization
- DCT cheat loading
- no$GBA save importing

The save-state loader now validates container lengths, chunk boundaries, record sizes, allocation limits, subsystem versions, collection counts, indices, and FIFO state. Each subsystem parses from an isolated bounded chunk stream.

The DCT loader validates the number of code pairs before indexing the fixed-size array, avoids modifying string-owned storage, handles missing separators safely, and rejects partially parsed entries.

The no$GBA importer validates declared input and output sizes, bounds every RLE operation, requires the declared decompressed size, and allocates according to the supported save size instead of using a fixed 1 MiB destination.

## Testing

- Windows x64 `Release Fastbuild`
- valid compressed and uncompressed save-state round trips
- original malformed save-state reproducer rejected without crashing
- eight targeted malformed save-state cases rejected
- DCT files with 1024 code pairs accepted and 1025 rejected
- valid no$GBA method 0 and method 1 saves converted correctly
- malformed and overflowing no$GBA streams rejected without crashing
- real Animal Crossing: Wild World ROM startup and save-state round trips